### PR TITLE
[WOOR-54] feat: 로그인 인증 기능 구현

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,5 +2,6 @@
 FROM openjdk:11-jdk
 EXPOSE 8080
 ARG JAR_FILE=/build/libs/woorimap-0.0.1-SNAPSHOT.jar
+VOLUME ["/var/log"]
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev","/app.jar"]

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -2,5 +2,6 @@
 FROM openjdk:11-jdk
 EXPOSE 8080
 ARG JAR_FILE=/build/libs/woorimap-0.0.1-SNAPSHOT.jar
+VOLUME ["/var/log"]
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod","/app.jar"]

--- a/src/main/java/com/musseukpeople/woorimap/HealthCheckController.java
+++ b/src/main/java/com/musseukpeople/woorimap/HealthCheckController.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,13 +8,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "헬스 체크", description = "헬스 체크 API입니다.")
+@Slf4j
 @RestController
 public class HealthCheckController {
 
-    @Operation(summary = "헬스 체크", description = "서버 실행 여부를 확인합니다.")
+    @Operation(summary = "서버 실행 헬스 체크", description = "서버 실행 여부를 확인합니다.")
     @GetMapping("/health")
     public String check() {
         return "Check This Sound";
+    }
+
+    @Operation(summary = "로그 헬스 체크", description = "로그 설정 여부를 확인합니다.")
+    @GetMapping("/health/log")
+    public String checkLog() {
+        log.debug("debug 로그 체크");
+        log.info("info 로그 체크");
+        log.warn("warn 로그 체크");
+        log.error("error 로그 체크");
+        return "Check Logs";
     }
 
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/AuthService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/AuthService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
-import com.musseukpeople.woorimap.auth.application.dto.response.MemberResponse;
+import com.musseukpeople.woorimap.auth.application.dto.response.LoginMemberResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
 import com.musseukpeople.woorimap.member.application.MemberService;
 import com.musseukpeople.woorimap.member.domain.Member;
@@ -32,11 +32,6 @@ public class AuthService {
         String accessToken = jwtProvider.createAccessToken(String.valueOf(memberId), coupleId);
         String refreshToken = jwtProvider.createRefreshToken(String.valueOf(memberId));
         tokenService.saveToken(refreshToken, memberId);
-
-        return new TokenResponse(
-            accessToken,
-            refreshToken,
-            new MemberResponse(member.getEmail().getValue(), member.getNickName().getValue())
-        );
+        return new TokenResponse(accessToken, refreshToken, LoginMemberResponse.from(member));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
@@ -11,4 +11,6 @@ public interface JwtProvider {
     boolean validateToken(String token);
 
     Claims getClaims(String token);
+
+    String getClaimName();
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/LoginMemberResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/LoginMemberResponse.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.auth.application.dto.response;
 
+import com.musseukpeople.woorimap.member.domain.Member;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -7,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class MemberResponse {
+public class LoginMemberResponse {
 
     @Schema(description = "이메일")
     private String email;
@@ -15,8 +17,12 @@ public class MemberResponse {
     @Schema(description = "닉네임")
     private String nickName;
 
-    public MemberResponse(String email, String nickName) {
+    public LoginMemberResponse(String email, String nickName) {
         this.email = email;
         this.nickName = nickName;
+    }
+
+    public static LoginMemberResponse from(Member member) {
+        return new LoginMemberResponse(member.getEmail().getValue(), member.getNickName().getValue());
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/TokenResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/TokenResponse.java
@@ -16,11 +16,11 @@ public class TokenResponse {
     private String refreshToken;
 
     @Schema(description = "멤버 정보")
-    private MemberResponse member;
+    private LoginMemberResponse member;
 
-    public TokenResponse(String accessToken, String refreshToken, MemberResponse memberResponse) {
+    public TokenResponse(String accessToken, String refreshToken, LoginMemberResponse loginMemberResponse) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.member = memberResponse;
+        this.member = loginMemberResponse;
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/login/Login.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/login/Login.java
@@ -1,0 +1,11 @@
+package com.musseukpeople.woorimap.auth.domain.login;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/login/LoginMember.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/login/LoginMember.java
@@ -1,0 +1,19 @@
+package com.musseukpeople.woorimap.auth.domain.login;
+
+import lombok.Getter;
+
+@Getter
+public class LoginMember {
+
+    private final Long id;
+    private final Long coupleId;
+
+    public LoginMember(Long id, Long coupleId) {
+        this.id = id;
+        this.coupleId = coupleId;
+    }
+
+    public boolean isCouple() {
+        return this.coupleId != null;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/exception/UnauthorizedException.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.musseukpeople.woorimap.auth.exception;
+
+import com.musseukpeople.woorimap.common.exception.BusinessException;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class UnauthorizedException extends BusinessException {
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/AuthorizationExtractor.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/AuthorizationExtractor.java
@@ -1,0 +1,39 @@
+package com.musseukpeople.woorimap.auth.infrastructure;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import com.google.common.base.Strings;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthorizationExtractor {
+
+    private static final String BEARER_TYPE = "Bearer";
+
+    public static Optional<String> extract(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION);
+
+        if (Strings.isNullOrEmpty(header)) {
+            return Optional.empty();
+        }
+        return extractToken(header);
+    }
+
+    private static Optional<String> extractToken(String header) {
+        if (header.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+            String authHeaderValue = header.substring(BEARER_TYPE.length()).trim();
+            int commaIndex = authHeaderValue.indexOf(',');
+            if (commaIndex > 0) {
+                authHeaderValue = authHeaderValue.substring(0, commaIndex);
+            }
+            return Optional.of(authHeaderValue);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
@@ -22,6 +22,8 @@ import io.jsonwebtoken.security.Keys;
 @Component
 public class JwtTokenProvider implements JwtProvider {
 
+    private static final String COUPLE_CLAIM_NAME = "coupleId";
+    
     private final String issuer;
     private final Key secretKey;
     private final long accessTokenValidityInMilliseconds;
@@ -54,7 +56,7 @@ public class JwtTokenProvider implements JwtProvider {
 
         return Jwts.builder()
             .setSubject(payload)
-            .claim("coupleId", coupleId)
+            .claim(COUPLE_CLAIM_NAME, coupleId)
             .setIssuer(issuer)
             .setIssuedAt(now)
             .setExpiration(validity)
@@ -81,6 +83,11 @@ public class JwtTokenProvider implements JwtProvider {
         } catch (JwtException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    @Override
+    public String getClaimName() {
+        return COUPLE_CLAIM_NAME;
     }
 
     private Jws<Claims> getClaimsJws(String token) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthArgumentResolver.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.musseukpeople.woorimap.auth.presentation;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.musseukpeople.woorimap.auth.application.JwtProvider;
+import com.musseukpeople.woorimap.auth.domain.login.Login;
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
+import com.musseukpeople.woorimap.auth.infrastructure.AuthorizationExtractor;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Login.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        String accessToken = AuthorizationExtractor.extract(httpServletRequest)
+            .orElseThrow(() -> new InvalidTokenException(null, ErrorCode.INVALID_TOKEN));
+
+        return getLoginMember(accessToken);
+    }
+
+    private LoginMember getLoginMember(String accessToken) {
+        Claims claims = jwtProvider.getClaims(accessToken);
+        String id = claims.getSubject();
+        Long coupleId = claims.get(jwtProvider.getClaimName(), Long.class);
+        return new LoginMember(Long.valueOf(id), coupleId);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
@@ -1,0 +1,41 @@
+package com.musseukpeople.woorimap.auth.presentation;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.musseukpeople.woorimap.auth.application.JwtProvider;
+import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
+import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
+import com.musseukpeople.woorimap.auth.infrastructure.AuthorizationExtractor;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+    
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
+        String accessToken = AuthorizationExtractor.extract(request)
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.UNAUTHORIZED));
+        validateAccessToken(accessToken);
+        return true;
+    }
+
+    private void validateAccessToken(String accessToken) {
+        if (!jwtProvider.validateToken(accessToken)) {
+            throw new InvalidTokenException(accessToken, ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -1,0 +1,33 @@
+package com.musseukpeople.woorimap.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.musseukpeople.woorimap.auth.application.JwtProvider;
+import com.musseukpeople.woorimap.auth.presentation.AuthArgumentResolver;
+import com.musseukpeople.woorimap.auth.presentation.AuthInterceptor;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthInterceptor(jwtProvider))
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/signin", "/api/members/signup");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthArgumentResolver(jwtProvider));
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -11,6 +11,17 @@ import com.musseukpeople.woorimap.auth.application.JwtProvider;
 import com.musseukpeople.woorimap.auth.presentation.AuthArgumentResolver;
 import com.musseukpeople.woorimap.auth.presentation.AuthInterceptor;
 
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.musseukpeople.woorimap.auth.application.JwtProvider;
+import com.musseukpeople.woorimap.auth.presentation.AuthArgumentResolver;
+import com.musseukpeople.woorimap.auth.presentation.AuthInterceptor;
+
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -36,5 +47,17 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/api/**")
             .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
             .exposedHeaders(HttpHeaders.LOCATION);
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthInterceptor(jwtProvider))
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/signin", "/api/members/signup");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AuthArgumentResolver(jwtProvider));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -29,5 +29,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new AuthArgumentResolver(jwtProvider));
+    private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
+            .exposedHeaders(HttpHeaders.LOCATION);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -3,19 +3,10 @@ package com.musseukpeople.woorimap.common.config;
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import com.musseukpeople.woorimap.auth.application.JwtProvider;
-import com.musseukpeople.woorimap.auth.presentation.AuthArgumentResolver;
-import com.musseukpeople.woorimap.auth.presentation.AuthInterceptor;
-
-import java.util.List;
-
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.musseukpeople.woorimap.auth.application.JwtProvider;
@@ -28,26 +19,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final JwtProvider jwtProvider;
-
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthInterceptor(jwtProvider))
-            .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/signin", "/api/members/signup");
-    }
-
-    @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new AuthArgumentResolver(jwtProvider));
     private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
+
+    private final JwtProvider jwtProvider;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
             .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
             .exposedHeaders(HttpHeaders.LOCATION);
-    private final JwtProvider jwtProvider;
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "U003", "존재하지 않는 사용자입니다."),
 
     // Auth
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A001", "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A001", "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다.");
 
     // Couple
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -22,7 +22,7 @@
     </springProfile>
 
     <springProfile name="prod,dev">
-        <property name="LOG_PATH" value="./logs"/>
+        <property name="LOG_PATH" value="/var/log"/>
         <include resource="appender/info-file-appender.xml"/>
         <include resource="appender/warn-file-appender.xml"/>
         <include resource="appender/error-file-appender.xml"/>

--- a/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/AuthorizationExtractorTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/AuthorizationExtractorTest.java
@@ -1,0 +1,43 @@
+package com.musseukpeople.woorimap.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class AuthorizationExtractorTest {
+
+    @DisplayName("헤더 토큰 추출 성공")
+    @Test
+    void extreact_success() {
+        // given
+        String headerToken = "Bearer token";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, headerToken);
+
+        // when
+        Optional<String> token = AuthorizationExtractor.extract(request);
+
+        // then
+        assertThat(token).isNotEmpty()
+            .get()
+            .isEqualTo("token");
+    }
+
+    @DisplayName("헤더에 값이 없음으로 인한 추출 실패")
+    @Test
+    void extreact_null_fail() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        Optional<String> token = AuthorizationExtractor.extract(request);
+
+        // then
+        assertThat(token).isEmpty();
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthArgumentResolverTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthArgumentResolverTest.java
@@ -1,0 +1,47 @@
+package com.musseukpeople.woorimap.auth.presentation;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.auth.infrastructure.JwtTokenProvider;
+
+class AuthArgumentResolverTest {
+
+    private static final JwtTokenProvider PROVIDER = new JwtTokenProvider(
+        "test",
+        "twk4jbz8a6smC4u0Xv6KvQUImMfVZ16/SCR0uKJIv3g=",
+        60_000,
+        60_000
+    );
+
+    private AuthArgumentResolver authArgumentResolver;
+
+    @BeforeEach
+    void setUp() {
+        authArgumentResolver = new AuthArgumentResolver(PROVIDER);
+    }
+
+    @DisplayName("Argument 변환 성공")
+    @Test
+    void resolveArgument_success() {
+        // given
+        String token = PROVIDER.createAccessToken("1", null);
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        NativeWebRequest request = new ServletWebRequest(servletRequest);
+
+        // when
+        Object result = authArgumentResolver.resolveArgument(null, null, request, null);
+
+        // then
+        assertThat(result).isInstanceOf(LoginMember.class);
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptorTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptorTest.java
@@ -1,0 +1,92 @@
+package com.musseukpeople.woorimap.auth.presentation;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
+import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
+import com.musseukpeople.woorimap.auth.infrastructure.JwtTokenProvider;
+
+class AuthInterceptorTest {
+
+    private static final JwtTokenProvider PROVIDER = new JwtTokenProvider(
+        "test",
+        "twk4jbz8a6smC4u0Xv6KvQUImMfVZ16/SCR0uKJIv3g=",
+        60_000,
+        60_000
+    );
+
+    private AuthInterceptor authInterceptor;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        authInterceptor = new AuthInterceptor(PROVIDER);
+        response = new MockHttpServletResponse();
+    }
+
+    @DisplayName("인터셉터 통과 성공")
+    @Test
+    void preHandle_success() {
+        // given
+        String token = PROVIDER.createAccessToken("1", null);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+        // when
+        boolean result = authInterceptor.preHandle(request, new MockHttpServletResponse(), null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("CORS 요청일 경우 인터셉터 통과 성공")
+    @Test
+    void preHandle_cors_success() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(HttpMethod.OPTIONS.name());
+        request.addHeader(HttpHeaders.ORIGIN, "http://localhost:8080");
+        request.addHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+
+        // when
+        boolean result = authInterceptor.preHandle(request, new MockHttpServletResponse(), null);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("헤더에 토큰이 없음으로 인한 실패")
+    @Test
+    void preHandle_notFoundToken_fail() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        // when
+        // then
+        assertThatThrownBy(() -> authInterceptor.preHandle(request, response, null))
+            .isInstanceOf(UnauthorizedException.class)
+            .hasMessage("로그인이 필요합니다.");
+    }
+
+    @DisplayName("유효하지 않은 토큰으로 인한 실패")
+    @Test
+    void preHandle_invalidToken_fail() {
+        // given
+        String token = "invalidToken";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+        // when
+        // then
+        assertThatThrownBy(() -> authInterceptor.preHandle(request, response, null))
+            .isInstanceOf(InvalidTokenException.class)
+            .hasMessageContaining("유효하지 않은 토큰입니다.");
+    }
+}


### PR DESCRIPTION
## 요약
- 로그인 인증 기능 구현

<br><br>

## 작업 내용
- 로그인 검증하는 인터셉터 구현(46bcb7baab21a84a55d2f4fa73080c7ec6bc115e)
- 회원아이디와 커플아이디 바인딩 해주는 resolver 구현(f109efa3e6ea5c68df99192d49b696043e0c4e5d)
  - `LoginMember`로 바인딩할 수 있도록 하였습니다. 
  - `@Login LoginMember`로 사용하시면 됩니다. 

<br><br>

## 참고 사항
- 현재는 인가할 것이 없어 따로 설정하진 않았지만 커플코드나 커플만이 접근할 수 있도록 구현하는 인가가 필요할 것 같습니다.
- **커플 코드 생성, 인증은 커플이 아닌 사람만 접근하게 하고 나머지는 커플인 사람들만 접근할 수 있도록 할까요??**

<br><br>
