### PR TITLE
[WOOR-111] chore: 로그백 & 도커 로그 볼륨 설정 추가

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -2,5 +2,6 @@
 FROM openjdk:11-jdk
 EXPOSE 8080
 ARG JAR_FILE=/build/libs/woorimap-0.0.1-SNAPSHOT.jar
+VOLUME ["/var/log"]
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev","/app.jar"]

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -2,5 +2,6 @@
 FROM openjdk:11-jdk
 EXPOSE 8080
 ARG JAR_FILE=/build/libs/woorimap-0.0.1-SNAPSHOT.jar
+VOLUME ["/var/log"]
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod","/app.jar"]

--- a/src/main/java/com/musseukpeople/woorimap/HealthCheckController.java
+++ b/src/main/java/com/musseukpeople/woorimap/HealthCheckController.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,13 +8,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "헬스 체크", description = "헬스 체크 API입니다.")
+@Slf4j
 @RestController
 public class HealthCheckController {
 
-    @Operation(summary = "헬스 체크", description = "서버 실행 여부를 확인합니다.")
+    @Operation(summary = "서버 실행 헬스 체크", description = "서버 실행 여부를 확인합니다.")
     @GetMapping("/health")
     public String check() {
         return "Check This Sound";
+    }
+
+    @Operation(summary = "로그 헬스 체크", description = "로그 설정 여부를 확인합니다.")
+    @GetMapping("/health/log")
+    public String checkLog() {
+        log.debug("debug 로그 체크");
+        log.info("info 로그 체크");
+        log.warn("warn 로그 체크");
+        log.error("error 로그 체크");
+        return "Check Logs";
     }
 
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -22,7 +22,7 @@
     </springProfile>
 
     <springProfile name="prod,dev">
-        <property name="LOG_PATH" value="./logs"/>
+        <property name="LOG_PATH" value="/var/log"/>
         <include resource="appender/info-file-appender.xml"/>
         <include resource="appender/warn-file-appender.xml"/>
         <include resource="appender/error-file-appender.xml"/>


### PR DESCRIPTION
## 요약
* 도커 컨테이너 내 로그 볼륨을 설정해줍니다.
<br><br>

## 작업 내용
* logback 내 log path 수정
* Docker 파일 로그 볼륨 설정 추가
* 볼륨이 제대로 설정되었는지 확인하기 위해 로그 헬스 체크 기능을 구현했습니다.
<br><br>

## 참고 사항
* 해당 설정을 통해 도커 컨테이너 내 /var/log 볼륨에 로깅 파일이 남겨집니다.
* 개발서버엔 docker-compose 파일 수정해서 /home/ec2-user/log 폴더에 로그가 남겨지도록 했습니다.

현재 개발서버 컴포즈 파일 상태
```
version: "3.9"

services:
  spring:
    image: woojin1380/woorimap-dev
    container_name: woorimap-dev
    ports:
      - "80:8080"
    volumes:
      - /home/ec2-user/log:/var/log
```
<br><br>