### PR TITLE
[WOOR-32] feat: 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/application/AuthService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/AuthService.java
@@ -34,4 +34,9 @@ public class AuthService {
         tokenService.saveToken(refreshToken, memberId);
         return new TokenResponse(accessToken, refreshToken, LoginMemberResponse.from(member));
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        tokenService.removeByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/TokenService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/TokenService.java
@@ -20,4 +20,9 @@ public class TokenService {
         Token token = new Token(refreshToken, memberId);
         tokenRepository.save(token);
     }
+
+    @Transactional
+    public void removeByMemberId(Long memberId) {
+        tokenRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/TokenRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/TokenRepository.java
@@ -3,4 +3,6 @@ package com.musseukpeople.woorimap.auth.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -37,6 +37,7 @@ public class AuthController {
     @Operation(summary = "로그아웃", description = "로그아웃 API입니다.")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@Login LoginMember loginMember) {
+        authService.logout(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -5,11 +5,14 @@ import javax.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.musseukpeople.woorimap.auth.application.AuthService;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
+import com.musseukpeople.woorimap.auth.domain.login.Login;
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,15 +21,22 @@ import lombok.RequiredArgsConstructor;
 
 @Tag(name = "인증", description = "인증 관련 API입니다.")
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
 
     @Operation(summary = "로그인", description = "로그인 API입니다.")
-    @PostMapping("api/signin")
+    @PostMapping("/signin")
     public ResponseEntity<ApiResponse<TokenResponse>> signIn(@Valid @RequestBody SignInRequest signInRequest) {
         TokenResponse tokenResponse = authService.login(signInRequest);
         return ResponseEntity.ok(new ApiResponse<>(tokenResponse));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃 API입니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@Login LoginMember loginMember) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃 API입니다.")
-    @PostMapping("/logout")
+    @PostMapping("/signout")
     public ResponseEntity<Void> logout(@Login LoginMember loginMember) {
         authService.logout(loginMember.getId());
         return ResponseEntity.noContent().build();

--- a/src/test/java/com/musseukpeople/woorimap/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/application/AuthServiceTest.java
@@ -40,11 +40,7 @@ class AuthServiceTest {
         // given
         String email = "woorimap@gmail.com";
         String password = "!Hwan123";
-        Member member = new TMemberBuilder()
-            .email(email)
-            .password(password)
-            .build();
-        memberRepository.save(member);
+        saveMember(email, password);
         SignInRequest signInRequest = new SignInRequest(email, password);
 
         // when
@@ -77,11 +73,7 @@ class AuthServiceTest {
     void login_invalidPassword_fail() {
         // given
         String email = "woorimap@gmail.com";
-        Member member = new TMemberBuilder()
-            .email(email)
-            .password("!Hwan123")
-            .build();
-        memberRepository.save(member);
+        saveMember(email, "!Hwan123");
         SignInRequest signInRequest = new SignInRequest(email, "!Test123");
 
         // when
@@ -89,5 +81,13 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.login(signInRequest))
             .isInstanceOf(LoginFailedException.class)
             .hasMessageContaining("이메일 또는 비밀번호가 일치하지 않습니다");
+    }
+
+    private void saveMember(String email, String password) {
+        Member member = new TMemberBuilder()
+            .email(email)
+            .password(password)
+            .build();
+        memberRepository.save(member);
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthControllerTest.java
@@ -2,12 +2,14 @@ package com.musseukpeople.woorimap.auth.presentation;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -72,6 +74,23 @@ class AuthControllerTest extends AcceptanceTest {
 
         // then
         로그인_실패(response);
+    }
+
+    @DisplayName("로그아웃 성공")
+    @Test
+    void logout_success() throws Exception {
+        // given
+        String email = "woorimap@gmail.com";
+        String password = "!Hwan123";
+        String accessToken = 로그인_토큰(new SignInRequest(email, password));
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(post("/api/logout")
+                .header(HttpHeaders.AUTHORIZATION, accessToken))
+            .andReturn().getResponse();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
     private void 로그인_실패(MockHttpServletResponse response) throws IOException {

--- a/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/presentation/AuthControllerTest.java
@@ -85,7 +85,7 @@ class AuthControllerTest extends AcceptanceTest {
         String accessToken = 로그인_토큰(new SignInRequest(email, password));
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/api/logout")
+        MockHttpServletResponse response = mockMvc.perform(post("/api/signout")
                 .header(HttpHeaders.AUTHORIZATION, accessToken))
             .andReturn().getResponse();
 

--- a/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
+import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
@@ -53,6 +54,11 @@ public abstract class AcceptanceTest {
                 .content(objectMapper.writeValueAsString(signInRequest)))
             .andDo(print())
             .andReturn().getResponse();
+    }
+
+    protected String 로그인_토큰(SignInRequest signInRequest) throws Exception {
+        MockHttpServletResponse response = 로그인(signInRequest);
+        return "Bearer" + getResponseObject(response, TokenResponse.class).getAccessToken();
     }
 
     protected ErrorResponse getErrorResponse(MockHttpServletResponse response) throws IOException {


### PR DESCRIPTION
## 요약
- 로그아웃 API 구현 

<br><br>

## 작업 내용
- 로그아웃시 저장한 refreshToken 삭제

<br><br>

## 참고 사항
- 기본 기능 구현하고 차후에 토큰은 redis로 저장하게 하고 추가적으로 블랙 리스트 기능도 구현해보겠습니다. 
- 참고 : [Redis 를 통한 JWT Blacklist 구현](https://velog.io/@boo105/Redis-%EB%A5%BC-%ED%86%B5%ED%95%9C-JWT-Blacklist-%EA%B5%AC%ED%98%84)

<br><br>
