### PR TITLE
[WOOR-33] feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/login/Login.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/login/Login.java
@@ -5,7 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface Login {
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
-    
+
     private final JwtProvider jwtProvider;
 
     @Override
@@ -28,7 +28,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         String accessToken = AuthorizationExtractor.extract(request)
-            .orElseThrow(() -> new UnauthorizedException(ErrorCode.UNAUTHORIZED));
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.NOT_FOUND_TOKEN));
         validateAccessToken(accessToken);
         return true;
     }

--- a/src/main/java/com/musseukpeople/woorimap/common/config/SwaggerConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/SwaggerConfig.java
@@ -2,10 +2,12 @@ package com.musseukpeople.woorimap.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
@@ -20,7 +22,10 @@ public class SwaggerConfig {
                     .name(securitySchemeName)
                     .type(SecurityScheme.Type.HTTP)
                     .scheme(securitySchemeName)
-                    .bearerFormat("JWT")))
+                    .bearerFormat("JWT")
+                    .in(SecurityScheme.In.HEADER)
+                    .name(HttpHeaders.AUTHORIZATION)))
+            .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
             .info(new Info().title("WooriMap"));
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -23,8 +23,8 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "U003", "존재하지 않는 사용자입니다."),
 
     // Auth
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A001", "유효하지 않은 토큰입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다.");
 
     // Couple
 

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
     HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", " 접근 권한이 없습니다."),
 
     // User
-    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "U001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "U001", "이메일 또는 비밀번호가 일치하지 않습니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "U002", "중복된 이메일입니다."),
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "U003", "존재하지 않는 사용자입니다."),
 

--- a/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
@@ -53,4 +53,9 @@ public class MemberService {
             throw new DuplicateEmailException(email, ErrorCode.DUPLICATE_EMAIL);
         }
     }
+
+    @Transactional
+    public void removeMember(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
@@ -4,11 +4,14 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.musseukpeople.woorimap.auth.domain.login.Login;
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.member.application.MemberService;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 
@@ -29,5 +32,11 @@ public class MemberController {
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignupRequest signupRequest) {
         memberService.createMember(signupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "멤버 회원 탈퇴", description = "멤버 회원 탈퇴 API입니다.")
+    @DeleteMapping
+    public ResponseEntity<Void> withdrawal(@Login LoginMember loginMember) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
@@ -37,6 +37,7 @@ public class MemberController {
     @Operation(summary = "멤버 회원 탈퇴", description = "멤버 회원 탈퇴 API입니다.")
     @DeleteMapping
     public ResponseEntity<Void> withdrawal(@Login LoginMember loginMember) {
+        memberService.removeMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -96,7 +96,7 @@ class AuthControllerTest extends AcceptanceTest {
     private void 로그인_실패(MockHttpServletResponse response) throws IOException {
         ErrorResponse errorResponse = getErrorResponse(response);
         assertAll(
-            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value()),
             () -> assertThat(errorResponse.getMessage()).isEqualTo("이메일 또는 비밀번호가 일치하지 않습니다."),
             () -> assertThat(errorResponse.getCode()).isEqualTo("U001")
         );

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.musseukpeople.woorimap.auth.presentation;
+package com.musseukpeople.woorimap.auth.acceptance;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
@@ -55,8 +54,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         // given
         String email = "test@gmail.com";
         String password = "!Hwan1234";
-        회원가입(new SignupRequest(email, password, "hwan"));
-        String accessToken = 로그인_토큰(new SignInRequest(email, password));
+        String accessToken = 회원가입_토큰(new SignupRequest(email, password, "hwan"));
 
         // when
         MockHttpServletResponse response = mockMvc.perform(delete("/api/members")

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -2,12 +2,15 @@ package com.musseukpeople.woorimap.member.acceptance;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
@@ -44,5 +47,22 @@ class MemberAcceptanceTest extends AcceptanceTest {
             () -> assertThat(errorResponse.getCode()).isEqualTo("U002"),
             () -> assertThat(errorResponse.getMessage()).isEqualTo("중복된 이메일입니다.")
         );
+    }
+
+    @DisplayName("회원 탈퇴 성공")
+    @Test
+    void withdrawal_success() throws Exception {
+        // given
+        String email = "woorimap@gmail.com";
+        String password = "!Hwan123";
+        String accessToken = 로그인_토큰(new SignInRequest(email, password));
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(delete("/api/members")
+                .header(HttpHeaders.AUTHORIZATION, accessToken))
+            .andReturn().getResponse();
+
+        // then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -53,8 +53,9 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void withdrawal_success() throws Exception {
         // given
-        String email = "woorimap@gmail.com";
-        String password = "!Hwan123";
+        String email = "test@gmail.com";
+        String password = "!Hwan1234";
+        회원가입(new SignupRequest(email, password, "hwan"));
         String accessToken = 로그인_토큰(new SignInRequest(email, password));
 
         // when

--- a/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
@@ -48,6 +48,11 @@ public abstract class AcceptanceTest {
             .andReturn().getResponse();
     }
 
+    protected String 회원가입_토큰(SignupRequest signupRequest) throws Exception {
+        회원가입(signupRequest);
+        return 로그인_토큰(new SignInRequest(signupRequest.getEmail(), signupRequest.getPassword()));
+    }
+
     protected MockHttpServletResponse 로그인(SignInRequest signInRequest) throws Exception {
         return mockMvc.perform(post("/api/signin")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## 요약
- 회원 탈퇴 API 구현
<br><br>

## 작업 내용
- 회원 탈퇴 기능 구현 
- Swaager JWT 토큰 넣을 수 있도록 했습니다. 
- Acceptance 테스트에서 회원가입 이후 바로 토큰 받을 수 있는 메서드 구현해놨습니다. (25901f92aad01c4b4634db4a06e1ec6cb9463584)
  - 리팩토링하면서 enum으로 로그인할 수 있도록 구현해보겠습니다.

<br><br>

## 참고 사항
- soft delete 구현할 건지 정하면 좋겠네요.
  - 저희 얘기할 땐 일단 soft delete 적용한다 했지 않나요..? 
  - 구체적인 정책이 있으면 좋겠습니다!
<br><br>
