### PR TITLE
[WOOR-118] feat: 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/application/TokenService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/TokenService.java
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.auth.domain.Token;
 import com.musseukpeople.woorimap.auth.domain.TokenRepository;
+import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,5 +26,10 @@ public class TokenService {
     @Transactional
     public void removeByMemberId(Long memberId) {
         tokenRepository.deleteByMemberId(memberId);
+    }
+
+    public Token getTokenByMemberId(Long memberId) {
+        return tokenRepository.findByMemberId(memberId)
+            .orElseThrow(() -> new InvalidTokenException(null, ErrorCode.INVALID_TOKEN));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/request/RefreshTokenRequest.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.auth.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RefreshTokenRequest {
 
+    @Schema(description = "리프레쉬 토큰")
     private String refreshToken;
 
     public RefreshTokenRequest(String refreshToken) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/request/RefreshTokenRequest.java
@@ -1,4 +1,4 @@
-package com.musseukpeople.woorimap.auth.presentation.dto.request;
+package com.musseukpeople.woorimap.auth.application.dto.request;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/AccessTokenResponse.java
@@ -1,0 +1,16 @@
+package com.musseukpeople.woorimap.auth.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccessTokenResponse {
+
+    private String accessToken;
+
+    public AccessTokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/dto/response/AccessTokenResponse.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.auth.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccessTokenResponse {
 
+    @Schema(description = "재발급 엑세스 토큰")
     private String accessToken;
 
     public AccessTokenResponse(String accessToken) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/Token.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/Token.java
@@ -29,4 +29,8 @@ public class Token {
         this.refreshToken = refreshToken;
         this.memberId = memberId;
     }
+
+    public boolean isNotSameToken(String refreshToken) {
+        return !this.refreshToken.equals(refreshToken);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/Token.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/Token.java
@@ -22,7 +22,7 @@ public class Token {
     @Column(nullable = false, unique = true)
     private String refreshToken;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private Long memberId;
 
     public Token(String refreshToken, Long memberId) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/TokenRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/TokenRepository.java
@@ -1,8 +1,12 @@
 package com.musseukpeople.woorimap.auth.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findByMemberId(Long memberId);
 
     void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.auth.presentation;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -10,9 +11,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.musseukpeople.woorimap.auth.application.AuthService;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
+import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
 import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
+import com.musseukpeople.woorimap.auth.infrastructure.AuthorizationExtractor;
+import com.musseukpeople.woorimap.auth.presentation.dto.request.RefreshTokenRequest;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,5 +45,13 @@ public class AuthController {
     public ResponseEntity<Void> logout(@Login LoginMember loginMember) {
         authService.logout(loginMember.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/tokens")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(HttpServletRequest httpServletRequest,
+                                                                               @Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
+        String accessToken = AuthorizationExtractor.extract(httpServletRequest)
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.NOT_FOUND_TOKEN));
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -47,6 +47,7 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "엑세스 토큰 재발급", description = "엑세스 토큰을 재발급 받습니다.")
     @PostMapping("/tokens")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(HttpServletRequest httpServletRequest,
                                                                                @Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.musseukpeople.woorimap.auth.application.AuthService;
+import com.musseukpeople.woorimap.auth.application.dto.request.RefreshTokenRequest;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
@@ -17,7 +18,6 @@ import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
 import com.musseukpeople.woorimap.auth.infrastructure.AuthorizationExtractor;
-import com.musseukpeople.woorimap.auth.presentation.dto.request.RefreshTokenRequest;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 
@@ -50,8 +50,13 @@ public class AuthController {
     @PostMapping("/tokens")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(HttpServletRequest httpServletRequest,
                                                                                @Valid @RequestBody RefreshTokenRequest refreshTokenRequest) {
-        String accessToken = AuthorizationExtractor.extract(httpServletRequest)
+        String accessToken = getAccessTokenByRequest(httpServletRequest);
+        AccessTokenResponse refreshAccessToken = authService.refreshAccessToken(accessToken, refreshTokenRequest);
+        return ResponseEntity.ok(new ApiResponse<>(refreshAccessToken));
+    }
+
+    private String getAccessTokenByRequest(HttpServletRequest httpServletRequest) {
+        return AuthorizationExtractor.extract(httpServletRequest)
             .orElseThrow(() -> new UnauthorizedException(ErrorCode.NOT_FOUND_TOKEN));
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,16 @@
+package com.musseukpeople.woorimap.auth.presentation.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshTokenRequest {
+
+    private String refreshToken;
+
+    public RefreshTokenRequest(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -34,7 +34,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor(jwtProvider))
             .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/signin", "/api/members/signup");
+            .excludePathPatterns("/api/signin", "/api/members/signup", "/api/tokens");
     }
 
     @Override

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -127,7 +127,7 @@ class AuthControllerTest extends AcceptanceTest {
         토큰_재발급_실패(response);
     }
 
-    @DisplayName("유요하지 않은 refreshToken으로 인한 토큰 재발급 실패")
+    @DisplayName("유효하지 않은 refreshToken으로 인한 토큰 재발급 실패")
     @Test
     void refreshAccessToken_invalidRefreshToken_fail() throws Exception {
         TokenResponse tokenResponse = 로그인_모든_토큰("woorimap@gmail.com", "!Hwan123");

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -14,10 +14,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import com.musseukpeople.woorimap.auth.application.dto.request.RefreshTokenRequest;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.TokenResponse;
-import com.musseukpeople.woorimap.auth.presentation.dto.request.RefreshTokenRequest;
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
@@ -100,16 +100,10 @@ class AuthControllerTest extends AcceptanceTest {
     @Test
     void refreshAccessToken_success() throws Exception {
         // given
-        MockHttpServletResponse loginResponse = 로그인(new SignInRequest("woorimap@gmail.com", "!Hwan123"));
-        TokenResponse tokenResponse = getResponseObject(loginResponse, TokenResponse.class);
-        RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest(tokenResponse.getRefreshToken());
+        TokenResponse tokenResponse = 로그인_모든_토큰("woorimap@gmail.com", "!Hwan123");
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/api/tokens")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken())
-                .content(objectMapper.writeValueAsString(refreshTokenRequest)))
-            .andReturn().getResponse();
+        MockHttpServletResponse response = 토큰_재발급_요청(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
 
         // then
         AccessTokenResponse accessTokenResponse = getResponseObject(response, AccessTokenResponse.class);
@@ -119,12 +113,60 @@ class AuthControllerTest extends AcceptanceTest {
         );
     }
 
+    @DisplayName("유효하지 않은 accessToken으로 인한 토큰 재발급 실패")
+    @Test
+    void refreshAccessToken_invalidAccessToken_fail() throws Exception {
+        // given
+        TokenResponse tokenResponse = 로그인_모든_토큰("woorimap@gmail.com", "!Hwan123");
+
+        // when
+        MockHttpServletResponse response = 토큰_재발급_요청(tokenResponse.getAccessToken() + "invalid",
+            tokenResponse.getRefreshToken());
+
+        // then
+        토큰_재발급_실패(response);
+    }
+
+    @DisplayName("유요하지 않은 refreshToken으로 인한 토큰 재발급 실패")
+    @Test
+    void refreshAccessToken_invalidRefreshToken_fail() throws Exception {
+        TokenResponse tokenResponse = 로그인_모든_토큰("woorimap@gmail.com", "!Hwan123");
+
+        // when
+        MockHttpServletResponse response = 토큰_재발급_요청(tokenResponse.getAccessToken(),
+            tokenResponse.getRefreshToken() + "invalid");
+
+        // then
+        토큰_재발급_실패(response);
+    }
+
+    private TokenResponse 로그인_모든_토큰(String email, String password) throws Exception {
+        SignInRequest signInRequest = new SignInRequest(email, password);
+        return getResponseObject(로그인(signInRequest), TokenResponse.class);
+    }
+
+    private MockHttpServletResponse 토큰_재발급_요청(String accessToken, String refreshToken) throws Exception {
+        return mockMvc.perform(post("/api/tokens")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .content(objectMapper.writeValueAsString(new RefreshTokenRequest(refreshToken))))
+            .andReturn().getResponse();
+    }
+
     private void 로그인_실패(MockHttpServletResponse response) throws IOException {
         ErrorResponse errorResponse = getErrorResponse(response);
         assertAll(
             () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value()),
             () -> assertThat(errorResponse.getMessage()).isEqualTo("이메일 또는 비밀번호가 일치하지 않습니다."),
             () -> assertThat(errorResponse.getCode()).isEqualTo("U001")
+        );
+    }
+
+    private void 토큰_재발급_실패(MockHttpServletResponse response) throws IOException {
+        ErrorResponse errorResponse = getErrorResponse(response);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value()),
+            () -> assertThat(errorResponse.getMessage()).isEqualTo("유효하지 않은 토큰입니다.")
         );
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
@@ -26,6 +26,10 @@ import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 @AutoConfigureMockMvc
 public abstract class AcceptanceTest {
 
+    static {
+        System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+    }
+
     @Autowired
     protected MockMvc mockMvc;
 


### PR DESCRIPTION
## 요약
- 엑세스 토큰 재발급 API 구현

<br><br>

## 작업 내용
- 엑세스 토큰 재발급 기능 구현 
  - 지금은 refreshToken을 바디로 받아서 처리하고 있는 데 프론트랑 좀 더 상의 해보고 어떻게 받을 지 더 봐야할 것 같습니다. 

<br><br>

## 참고 사항
- 로그아웃을 하지 않고 다시 로그인하면  유니크키 때문에 예외가 발생합니다!!!!
- 현재 로직이 매우 더러워서 마음에 들지 않는데 레디스로 변경하면서 리팩토링해보겠습니다.


<br><br>
