### PR TITLE
[WOOR-140] fix: redis 연결 문제 해결

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/common/config/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/redis/EmbeddedRedisConfig.java
@@ -30,7 +30,7 @@ public class EmbeddedRedisConfig {
     private static final String BIN_SH_OPTION_WINDOW_ONE = "/y";
     private static final String BIN_SH_OPTION_WINDOW_TWO = "/c";
     private static final String COMMAND = "netstat -nat | grep LISTEN|grep %d";
-    private static final String COMMAND_WINDOW = "netstat -nao | find \"LISTEN\" | find %d";
+    private static final String COMMAND_WINDOW = "netstat -nao | findstr %d";
     private static final int START_PORT = 10000;
     private static final int END_PORT = 65535;
 
@@ -48,6 +48,10 @@ public class EmbeddedRedisConfig {
     public void redisServer() throws IOException {
         int port = isRedisRunning() ? findAvailablePort() : redisPort;
         redisServer = new RedisServer(port);
+        redisServer = RedisServer.builder()
+            .port(port)
+            .setting("maxmemory 128M")
+            .build();
         redisServer.start();
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
@@ -31,8 +31,7 @@ public class RedisConfig {
     @Bean
     @ConditionalOnMissingBean(RedisConnectionFactory.class)
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration configuration =
-            new RedisStandaloneConfiguration(host, port);
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
         configuration.setPassword(password);
         return new LettuceConnectionFactory(configuration);
     }


### PR DESCRIPTION
## 요약
-  redis 연결 문제 해결
<br><br>

## 작업 내용
- docker 컨테이너의 localhost는 docker 내부 ip에 바인딩 되기 때문에 외부 호스트에 접속이 안되는 문제 발생 
  - docker-compose 파일에 `extra_hosts` 옵션 추가 및 host `host.docker.internal`로 바인딩 처리 
- embedded redis 윈도우 환경에서 바인딩 안되는 문제 
  - 명령어를 바꿈으로써 해결  

<br><br>

## 참고 사항
- 더 자세히 보기 👉 [Redis 연결 오류](https://www.notion.so/backend-devcourse/Redis-52299783286940d1b5d4ea49ef59eaa6)

<br><br>
