### PR TITLE
[WOOR-69] feat: 커플 해제 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -24,9 +24,10 @@ public enum ErrorCode {
 
     // Auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
-    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다.");
+    NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다."),
 
     // Couple
+    NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다.");
 
     // Post
 

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -3,23 +3,30 @@ package com.musseukpeople.woorimap.couple.application;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
+import com.musseukpeople.woorimap.member.application.MemberService;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CoupleFacade {
 
+    private final MemberService memberService;
     private final CoupleService coupleService;
     private final InviteCodeService inviteCodeService;
 
+    @Transactional
     public InviteCodeResponse createInviteCode(Long inviterId, LocalDateTime expireDate) {
         return inviteCodeService.createInviteCode(inviterId, expireDate);
     }
 
+    @Transactional
     public void removeCouple(Long coupleId) {
+        memberService.breakUpMembersByCoupleId(coupleId);
         coupleService.removeCouple(coupleId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -18,4 +18,8 @@ public class CoupleFacade {
     public InviteCodeResponse createInviteCode(Long inviterId, LocalDateTime expireDate) {
         return inviteCodeService.createInviteCode(inviterId, expireDate);
     }
+
+    public void removeCouple(Long coupleId) {
+        coupleService.removeCouple(coupleId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -3,7 +3,10 @@ package com.musseukpeople.woorimap.couple.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.couple.exception.NotFoundCoupleException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +19,10 @@ public class CoupleService {
 
     @Transactional
     public void removeCouple(Long coupleId) {
+        Couple couple = coupleRepository.findById(coupleId)
+            .orElseThrow(() -> new NotFoundCoupleException(ErrorCode.NOT_FOUND_COUPLE, coupleId));
+        couple.clearMembers();
+
         coupleRepository.deleteById(coupleId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -1,6 +1,7 @@
 package com.musseukpeople.woorimap.couple.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 
@@ -8,7 +9,13 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CoupleService {
 
     private final CoupleRepository coupleRepository;
+
+    @Transactional
+    public void removeCouple(Long coupleId) {
+        coupleRepository.deleteById(coupleId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -3,10 +3,7 @@ package com.musseukpeople.woorimap.couple.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.musseukpeople.woorimap.common.exception.ErrorCode;
-import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
-import com.musseukpeople.woorimap.couple.exception.NotFoundCoupleException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,10 +16,6 @@ public class CoupleService {
 
     @Transactional
     public void removeCouple(Long coupleId) {
-        Couple couple = coupleRepository.findById(coupleId)
-            .orElseThrow(() -> new NotFoundCoupleException(ErrorCode.NOT_FOUND_COUPLE, coupleId));
-        couple.clearMembers();
-
         coupleRepository.deleteById(coupleId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -3,14 +3,18 @@ package com.musseukpeople.woorimap.couple.domain;
 import static com.google.common.base.Preconditions.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 import com.musseukpeople.woorimap.common.model.BaseEntity;
+import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,10 +25,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Couple extends BaseEntity {
 
+    @OneToMany(mappedBy = "couple")
+    private final List<Member> members = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Column(nullable = false)
     private LocalDate startDate;
 
@@ -38,5 +43,18 @@ public class Couple extends BaseEntity {
 
         this.id = id;
         this.startDate = startDate;
+    }
+
+    public void addMember(Member member) {
+        this.members.add(member);
+
+        if (member.getCouple() != this) {
+            member.changeCouple(this);
+        }
+    }
+
+    public void clearMembers() {
+        this.members.forEach(member -> member.changeCouple(null));
+        this.members.clear();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -48,13 +48,6 @@ public class Couple extends BaseEntity {
     public void addMember(Member member) {
         this.members.add(member);
 
-        if (member.getCouple() != this) {
-            member.changeCouple(this);
-        }
-    }
-
-    public void clearMembers() {
-        this.members.forEach(member -> member.changeCouple(null));
-        this.members.clear();
+        member.changeCouple(this);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -25,13 +25,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Couple extends BaseEntity {
 
-    @OneToMany(mappedBy = "couple")
-    private final List<Member> members = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(nullable = false)
     private LocalDate startDate;
+
+    @OneToMany(mappedBy = "couple")
+    private List<Member> members = new ArrayList<>();
 
     public Couple(LocalDate startDate) {
         this(null, startDate);

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -47,6 +47,12 @@ public class Couple extends BaseEntity {
         this.startDate = startDate;
     }
 
+    public Couple(Long id, LocalDate startDate, Member inviter, Member receiver) {
+        this(id, startDate);
+        addMember(inviter);
+        addMember(receiver);
+    }
+
     public void addMember(Member member) {
         this.members.add(member);
 

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/CoupleRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/CoupleRepository.java
@@ -2,5 +2,7 @@ package com.musseukpeople.woorimap.couple.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CoupleRepository extends JpaRepository<Couple, Long> {
+import com.musseukpeople.woorimap.couple.infrastructure.CoupleQueryRepository;
+
+public interface CoupleRepository extends JpaRepository<Couple, Long>, CoupleQueryRepository {
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/CoupleException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/CoupleException.java
@@ -1,0 +1,15 @@
+package com.musseukpeople.woorimap.couple.exception;
+
+import com.musseukpeople.woorimap.common.exception.BusinessException;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class CoupleException extends BusinessException {
+
+    public CoupleException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public CoupleException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
@@ -1,0 +1,14 @@
+package com.musseukpeople.woorimap.couple.exception;
+
+import static java.text.MessageFormat.*;
+
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class NotFoundCoupleException extends CoupleException {
+
+    private static final String ERROR_MESSAGE_FORMAT = "존재하지 않는 커플입니다. 커플 번호: {0}";
+
+    public NotFoundCoupleException(ErrorCode errorCode, Long coupleId) {
+        super(format(ERROR_MESSAGE_FORMAT, coupleId), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
@@ -2,9 +2,10 @@ package com.musseukpeople.woorimap.couple.exception;
 
 import static java.text.MessageFormat.*;
 
+import com.musseukpeople.woorimap.common.exception.BusinessException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
-public class NotFoundCoupleException extends CoupleException {
+public class NotFoundCoupleException extends BusinessException {
 
     private static final String ERROR_MESSAGE_FORMAT = "존재하지 않는 커플입니다. 커플 번호: {0}";
 

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/CoupleQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/CoupleQueryRepository.java
@@ -1,0 +1,4 @@
+package com.musseukpeople.woorimap.couple.infrastructure;
+
+public interface CoupleQueryRepository {
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/CoupleQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/CoupleQueryRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.musseukpeople.woorimap.couple.infrastructure;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CoupleQueryRepositoryImpl implements CoupleQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +26,13 @@ import lombok.RequiredArgsConstructor;
 public class CoupleController {
 
     private final CoupleFacade coupleFacade;
+
+    @Operation(summary = "커플 해제", description = "커플 해제 API입니다.")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCouple(@Login LoginMember member) {
+        coupleFacade.removeCouple(member.getCoupleId());
+        return ResponseEntity.noContent().build();
+    }
 
     @Operation(summary = "커플 초대 코드 생성", description = "커플 초대 코드 생성 API입니다.")
     @PostMapping("/invite")

--- a/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
@@ -58,4 +58,9 @@ public class MemberService {
     public void removeMember(Long memberId) {
         memberRepository.deleteById(memberId);
     }
+
+    @Transactional
+    public void breakUpMembersByCoupleId(Long coupleId) {
+        memberRepository.updateCoupleIdSetNull(coupleId);
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.member.domain;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.couple WHERE m.email.value = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.couple = null WHERE m.couple.id = :coupleId")
+    void updateCoupleIdSetNull(Long coupleId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
@@ -14,7 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.couple WHERE m.email.value = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Member m SET m.couple = null WHERE m.couple.id = :coupleId")
     void updateCoupleIdSetNull(Long coupleId);
 }

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
@@ -1,0 +1,46 @@
+package com.musseukpeople.woorimap.couple.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+
+@SpringBootTest
+class CoupleServiceTest {
+
+    private static final Long COUPLE_ID = 1L;
+    private static final LocalDate COUPLE_START_DATE = LocalDate.of(2022, 1, 1);
+
+    @Autowired
+    private CoupleService coupleService;
+
+    @Autowired
+    private CoupleRepository coupleRepository;
+
+    @BeforeEach
+    void setup() {
+        coupleRepository.save(new Couple(COUPLE_ID, COUPLE_START_DATE));
+    }
+
+    @DisplayName("커플 삭제 성공")
+    @Test
+    void remove_success() {
+        //given
+        coupleService.removeCouple(COUPLE_ID);
+
+        //when
+        Optional<Couple> foundCouple = coupleRepository.findById(COUPLE_ID);
+
+        //then
+        assertThat(foundCouple).isEmpty();
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
@@ -9,13 +9,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.util.IntegrationTest;
 
-@SpringBootTest
-class CoupleServiceTest {
+class CoupleServiceTest extends IntegrationTest {
 
     private static final Long COUPLE_ID = 1L;
     private static final LocalDate COUPLE_START_DATE = LocalDate.of(2022, 1, 1);

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
@@ -9,14 +9,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
 import com.musseukpeople.woorimap.couple.domain.InviteCodeRepository;
+import com.musseukpeople.woorimap.util.IntegrationTest;
 
-@SpringBootTest
-class InviteCodeServiceTest {
+class InviteCodeServiceTest extends IntegrationTest {
 
     private static final LocalDateTime EXPIRE_DATE = LocalDateTime.now().plusDays(1);
     private static final String INVITE_CODE = "1234567";


### PR DESCRIPTION
## 요약
커플 해제 API 구현
<br><br>

## 작업 내용
- Couple에 member 양방향 연관관계
  - 연관관계 편의 메소드
  - couple 삭제시 member의 couple 제거

- Couple 서비스
  - 삭제 기능 구현

- Error
  - ErrorCode에 NotFoundCouple 추가
  - CoupleException 생성
  - NotFoundCoupleException 생성
<br><br>

## 참고 사항
- 커플 해제 시에 저렇게 커플을 find 한 후 일일이 Member에 관한 연관관계를 끊어야 할까요? 좀 더 좋은 방법은 없을지??

- 컨벤션이 잘못됐나 커플 엔티티가 이상하게 커밋되네요??

- 커플 해제 API 테스트 관련해서는 커플 맺기 API가 완료된 후 리펙토링 하도록 하겠습니다.....ㅠ

- 커플 Exception에 추가되는 예외가 추가되면 NotFoundCoupleException 리펙토링 하겠습니다ㅠ
<br><br>
