### PR TITLE
[WOOR-145] fix : cors origin 및 credentials 설정

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
@@ -84,7 +84,7 @@ public class JwtTokenProvider implements JwtProvider {
             return getClaimsJws(token).getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
-        } catch (JwtException e) {
+        } catch (JwtException | IllegalArgumentException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/fake/FakeAuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/fake/FakeAuthController.java
@@ -124,15 +124,19 @@ public class FakeAuthController {
         private String accessToken;
         private String refreshToken;
 
-        public FakeTokenDto(String accessToken, String refreshToken) {
+        private LoginMemberResponse member;
+
+        public FakeTokenDto(String accessToken, String refreshToken, LoginMemberResponse member) {
             this.accessToken = accessToken;
             this.refreshToken = refreshToken;
+            this.member = member;
         }
 
         public static FakeTokenDto from(LoginResponseDto loginResponseDto) {
             return new FakeTokenDto(
                 loginResponseDto.getAccessToken().getValue(),
-                loginResponseDto.getRefreshToken().getValue()
+                loginResponseDto.getRefreshToken().getValue(),
+                loginResponseDto.getMember()
             );
         }
     }

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -29,8 +29,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
+            .allowedOriginPatterns("http://localhost:3000")
             .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
-            .exposedHeaders(HttpHeaders.LOCATION);
+            .allowCredentials(true)
+            .exposedHeaders(HttpHeaders.LOCATION)
+            .maxAge(3600);
     }
 
     @Override


### PR DESCRIPTION
## 요약
- cors origin 및 credentials 설정

<br><br>

## 작업 내용
- origin `http://localhost:3000`로 지정 
- credentials true 설정 

<br><br>

## 참고 사항
- 현재 쿠키 same-site 정책때문에 https를 적용하지 않는 이상 클라이언트쪽에서 사용하지 못합니다. 
- 이에 일단 fake api를 구현하였고 후에 https를 적용하면 삭제할 계획입니다.

<br><br>
