### PR TITLE
[WOOR-70] feat: 커플 맺기 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
     NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다."),
 
     // Couple
-    NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다.");
+    NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다."),
+    NOT_CREATE_COUPLE(HttpStatus.BAD_REQUEST, "CP002", "커플 맺기 실패했습니다"),
+
+    // InviteCode
+    NOT_FOUND_INVITE_CODE(HttpStatus.NOT_FOUND, "I001", "존재하지 않는 코드입니다.");
 
     // Post
 

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // Couple
     NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다."),
     NOT_CREATE_COUPLE(HttpStatus.BAD_REQUEST, "CP002", "커플 맺기 실패했습니다"),
+    ALREADY_COUPLE(HttpStatus.BAD_REQUEST, "CP003", "이미 커플입니다."),
 
     // InviteCode
     NOT_FOUND_INVITE_CODE(HttpStatus.NOT_FOUND, "I001", "존재하지 않는 코드입니다.");

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -2,6 +2,7 @@ package com.musseukpeople.woorimap.couple.application;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.stereotype.Component;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
+import com.musseukpeople.woorimap.couple.exception.AlreadyCoupleException;
 import com.musseukpeople.woorimap.couple.exception.CreateCoupleFailException;
 import com.musseukpeople.woorimap.member.application.MemberService;
 import com.musseukpeople.woorimap.member.domain.Member;
@@ -30,15 +32,16 @@ public class CoupleFacade {
         Long receiverId = receiver.getId();
         Long inviterId = inviteCodeService.getInviterIdByInviteCode(inviteCode);
 
-        if (Objects.equals(inviterId, receiverId)) {
-            throw new CreateCoupleFailException("자기 자신이 커플을 맺을 수 없습니다.", ErrorCode.NOT_CREATE_COUPLE);
-        }
+        validateSameInviter(receiverId, inviterId);
 
         Member foundInviter = memberService.getMemberById(inviterId);
         Member foundReceiver = memberService.getMemberById(receiverId);
 
+        validateAlreadyCouple(foundInviter, foundReceiver);
+
+        List<Member> members = List.of(foundInviter, foundReceiver);
         LocalDate createCoupleDate = LocalDate.now();
-        coupleService.createCouple(foundInviter, foundReceiver, createCoupleDate);
+        coupleService.createCouple(members, createCoupleDate);
         inviteCodeService.removeInviteCodeByCreatedCouple(inviterId, receiverId);
     }
 
@@ -52,5 +55,17 @@ public class CoupleFacade {
         Long coupleId = member.getCoupleId();
         memberService.breakUpMembersByCoupleId(coupleId);
         coupleService.removeCouple(coupleId);
+    }
+
+    private void validateAlreadyCouple(Member foundInviter, Member foundReceiver) {
+        if (foundInviter.isCouple() || foundReceiver.isCouple()) {
+            throw new AlreadyCoupleException(ErrorCode.ALREADY_COUPLE);
+        }
+    }
+
+    private void validateSameInviter(Long receiverId, Long inviterId) {
+        if (Objects.equals(inviterId, receiverId)) {
+            throw new CreateCoupleFailException("자기 자신이 커플을 맺을 수 없습니다.", ErrorCode.NOT_CREATE_COUPLE);
+        }
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -1,12 +1,18 @@
 package com.musseukpeople.woorimap.couple.application;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
+import com.musseukpeople.woorimap.couple.exception.CreateCoupleFailException;
 import com.musseukpeople.woorimap.member.application.MemberService;
+import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,12 +26,30 @@ public class CoupleFacade {
     private final InviteCodeService inviteCodeService;
 
     @Transactional
+    public void createCouple(String inviteCode, LoginMember receiver) {
+        Long receiverId = receiver.getId();
+        Long inviterId = inviteCodeService.getInviterIdByInviteCode(inviteCode);
+
+        if (Objects.equals(inviterId, receiverId)) {
+            throw new CreateCoupleFailException("자기 자신이 커플을 맺을 수 없습니다.", ErrorCode.NOT_CREATE_COUPLE);
+        }
+
+        Member foundInviter = memberService.getMemberById(inviterId);
+        Member foundReceiver = memberService.getMemberById(receiverId);
+
+        LocalDate createCoupleDate = LocalDate.now();
+        coupleService.createCouple(foundInviter, foundReceiver, createCoupleDate);
+        inviteCodeService.removeInviteCodeByCreatedCouple(inviterId, receiverId);
+    }
+
+    @Transactional
     public InviteCodeResponse createInviteCode(Long inviterId, LocalDateTime expireDate) {
         return inviteCodeService.createInviteCode(inviterId, expireDate);
     }
 
     @Transactional
-    public void removeCouple(Long coupleId) {
+    public void removeCouple(LoginMember member) {
+        Long coupleId = member.getCoupleId();
         memberService.breakUpMembersByCoupleId(coupleId);
         coupleService.removeCouple(coupleId);
     }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -30,7 +30,7 @@ public class CoupleFacade {
     @Transactional
     public void createCouple(String inviteCode, LoginMember receiver) {
         Long receiverId = receiver.getId();
-        Long inviterId = inviteCodeService.getInviterIdByInviteCode(inviteCode);
+        Long inviterId = inviteCodeService.getIdByCode(inviteCode);
 
         validateSameInviter(receiverId, inviterId);
 
@@ -42,7 +42,7 @@ public class CoupleFacade {
         List<Member> members = List.of(foundInviter, foundReceiver);
         LocalDate createCoupleDate = LocalDate.now();
         coupleService.createCouple(members, createCoupleDate);
-        inviteCodeService.removeInviteCodeByCreatedCouple(inviterId, receiverId);
+        inviteCodeService.removeInviteCodeByMembers(members);
     }
 
     @Transactional

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -1,9 +1,15 @@
 package com.musseukpeople.woorimap.couple.application;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,5 +23,12 @@ public class CoupleService {
     @Transactional
     public void removeCouple(Long coupleId) {
         coupleRepository.deleteById(coupleId);
+    }
+
+    @Transactional
+    public Long createCouple(Member inviter, Member receiver, LocalDate createCoupleDate) {
+        CoupleMembers coupleMembers = new CoupleMembers(List.of(inviter, receiver));
+        Couple couple = coupleRepository.save(new Couple(createCoupleDate, coupleMembers));
+        return couple.getId();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -26,8 +26,8 @@ public class CoupleService {
     }
 
     @Transactional
-    public Long createCouple(Member inviter, Member receiver, LocalDate createCoupleDate) {
-        CoupleMembers coupleMembers = new CoupleMembers(List.of(inviter, receiver));
+    public Long createCouple(List<Member> members, LocalDate createCoupleDate) {
+        CoupleMembers coupleMembers = new CoupleMembers(members);
         Couple couple = coupleRepository.save(new Couple(createCoupleDate, coupleMembers));
         return couple.getId();
     }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
@@ -1,6 +1,8 @@
 package com.musseukpeople.woorimap.couple.application;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +12,7 @@ import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResp
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
 import com.musseukpeople.woorimap.couple.domain.InviteCodeRepository;
 import com.musseukpeople.woorimap.couple.exception.NotFoundInviteCodeException;
+import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,13 +34,19 @@ public class InviteCodeService {
         return new InviteCodeResponse(inviteCode.getCode());
     }
 
-    public Long getInviterIdByInviteCode(String inviteCode) {
+    public Long getIdByCode(String inviteCode) {
         InviteCode foundInviteCode = inviteCodeRepository.findById(inviteCode)
             .orElseThrow(() -> new NotFoundInviteCodeException(ErrorCode.NOT_FOUND_INVITE_CODE, inviteCode));
         return foundInviteCode.getInviterId();
     }
 
-    public void removeInviteCodeByCreatedCouple(Long inviterId, Long receiverId) {
-        inviteCodeRepository.deleteByTwoMemberId(inviterId, receiverId);
+    public void removeInviteCodeByMembers(List<Member> members) {
+        inviteCodeRepository.deleteByInIds(createMemberIds(members));
+    }
+
+    private List<Long> createMemberIds(List<Member> members) {
+        List<Long> ids = new ArrayList<>();
+        members.forEach(member -> ids.add(member.getId()));
+        return ids;
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
@@ -5,9 +5,11 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
 import com.musseukpeople.woorimap.couple.domain.InviteCodeRepository;
+import com.musseukpeople.woorimap.couple.exception.NotFoundInviteCodeException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,5 +29,15 @@ public class InviteCodeService {
             );
 
         return new InviteCodeResponse(inviteCode.getCode());
+    }
+
+    public Long getInviterIdByInviteCode(String inviteCode) {
+        InviteCode foundInviteCode = inviteCodeRepository.findById(inviteCode)
+            .orElseThrow(() -> new NotFoundInviteCodeException(ErrorCode.NOT_FOUND_INVITE_CODE, inviteCode));
+        return foundInviteCode.getInviterId();
+    }
+
+    public void removeInviteCodeByCreatedCouple(Long inviterId, Long receiverId) {
+        inviteCodeRepository.deleteByTwoMemberId(inviterId, receiverId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/InviteCodeService.java
@@ -1,8 +1,8 @@
 package com.musseukpeople.woorimap.couple.application;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,12 +41,7 @@ public class InviteCodeService {
     }
 
     public void removeInviteCodeByMembers(List<Member> members) {
-        inviteCodeRepository.deleteByInIds(createMemberIds(members));
-    }
-
-    private List<Long> createMemberIds(List<Member> members) {
-        List<Long> ids = new ArrayList<>();
-        members.forEach(member -> ids.add(member.getId()));
-        return ids;
+        List<Long> ids = members.stream().map(Member::getId).collect(Collectors.toList());
+        inviteCodeRepository.deleteByInIds(ids);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/dto/request/CreateCoupleRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/dto/request/CreateCoupleRequest.java
@@ -1,0 +1,23 @@
+package com.musseukpeople.woorimap.couple.application.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateCoupleRequest {
+
+    @Schema(description = "커플 코드")
+    @NotBlank(message = "커플 코드를 입력해 주세요")
+    @Size(min = 7, max = 7, message = "코드 길이가 올바르지 않습니다")
+    private String code;
+
+    public CreateCoupleRequest(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -3,7 +3,6 @@ package com.musseukpeople.woorimap.couple.domain;
 import static com.google.common.base.Preconditions.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -14,7 +13,6 @@ import javax.persistence.Id;
 
 import com.musseukpeople.woorimap.common.model.BaseEntity;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
-import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -46,10 +44,6 @@ public class Couple extends BaseEntity {
         this.id = id;
         this.startDate = startDate;
         this.coupleMembers = coupleMembers;
-        addMembers(this.coupleMembers.getMembers());
-    }
-
-    private void addMembers(List<Member> members) {
-        members.forEach(member -> member.changeCouple(this));
+        this.coupleMembers.addMembers(this);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -3,17 +3,17 @@ package com.musseukpeople.woorimap.couple.domain;
 import static com.google.common.base.Preconditions.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 
 import com.musseukpeople.woorimap.common.model.BaseEntity;
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
 
 import lombok.AccessLevel;
@@ -32,30 +32,24 @@ public class Couple extends BaseEntity {
     @Column(nullable = false)
     private LocalDate startDate;
 
-    @OneToMany(mappedBy = "couple")
-    private List<Member> members = new ArrayList<>();
+    @Embedded
+    private CoupleMembers coupleMembers;
 
-    public Couple(LocalDate startDate) {
-        this(null, startDate);
+    public Couple(LocalDate startDate, CoupleMembers coupleMembers) {
+        this(null, startDate, coupleMembers);
     }
 
-    public Couple(Long id, LocalDate startDate) {
+    public Couple(Long id, LocalDate startDate, CoupleMembers coupleMembers) {
         checkArgument(startDate.isBefore(LocalDate.now().plusDays(1)),
             "현재 이후 날짜로 커플을 생성할 수 없습니다.");
 
         this.id = id;
         this.startDate = startDate;
+        this.coupleMembers = coupleMembers;
+        addMembers(this.coupleMembers.getMembers());
     }
 
-    public Couple(Long id, LocalDate startDate, Member inviter, Member receiver) {
-        this(id, startDate);
-        addMember(inviter);
-        addMember(receiver);
-    }
-
-    public void addMember(Member member) {
-        this.members.add(member);
-
-        member.changeCouple(this);
+    private void addMembers(List<Member> members) {
+        members.forEach(member -> member.changeCouple(this));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembers.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembers.java
@@ -8,14 +8,16 @@ import java.util.List;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
 
+import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.member.domain.Member;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoupleMembers {
 
     private static final int COUPLE_MEMBERS_SIZE = 2;
@@ -26,6 +28,10 @@ public class CoupleMembers {
     public CoupleMembers(List<Member> members) {
         validateCoupleMembers(members);
         this.members = members;
+    }
+
+    public void addMembers(Couple couple) {
+        this.members.forEach(member -> member.changeCouple(couple));
     }
 
     private void validateCoupleMembers(List<Member> members) {

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembers.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembers.java
@@ -1,0 +1,34 @@
+package com.musseukpeople.woorimap.couple.domain.vo;
+
+import static com.google.common.base.Preconditions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+
+import com.musseukpeople.woorimap.member.domain.Member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class CoupleMembers {
+
+    private static final int COUPLE_MEMBERS_SIZE = 2;
+
+    @OneToMany(mappedBy = "couple")
+    private List<Member> members = new ArrayList<>();
+
+    public CoupleMembers(List<Member> members) {
+        validateCoupleMembers(members);
+        this.members = members;
+    }
+
+    private void validateCoupleMembers(List<Member> members) {
+        checkArgument(members.size() == COUPLE_MEMBERS_SIZE, "커플 인원이 2명이 아닙니다");
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/AlreadyCoupleException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/AlreadyCoupleException.java
@@ -1,0 +1,10 @@
+package com.musseukpeople.woorimap.couple.exception;
+
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class AlreadyCoupleException extends CoupleException {
+
+    public AlreadyCoupleException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/CreateCoupleFailException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/CreateCoupleFailException.java
@@ -1,0 +1,10 @@
+package com.musseukpeople.woorimap.couple.exception;
+
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class CreateCoupleFailException extends CoupleException {
+
+    public CreateCoupleFailException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundCoupleException.java
@@ -2,10 +2,9 @@ package com.musseukpeople.woorimap.couple.exception;
 
 import static java.text.MessageFormat.*;
 
-import com.musseukpeople.woorimap.common.exception.BusinessException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
-public class NotFoundCoupleException extends BusinessException {
+public class NotFoundCoupleException extends CoupleException {
 
     private static final String ERROR_MESSAGE_FORMAT = "존재하지 않는 커플입니다. 커플 번호: {0}";
 

--- a/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundInviteCodeException.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/exception/NotFoundInviteCodeException.java
@@ -1,0 +1,14 @@
+package com.musseukpeople.woorimap.couple.exception;
+
+import static java.text.MessageFormat.*;
+
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class NotFoundInviteCodeException extends CoupleException {
+
+    private static final String ERROR_MESSAGE_FORMAT = "존재하지 않는 코드입니다. 커플 코드: {0}";
+
+    public NotFoundInviteCodeException(ErrorCode errorCode, String inviteCode) {
+        super(format(ERROR_MESSAGE_FORMAT, inviteCode), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepository.java
@@ -7,4 +7,6 @@ import com.musseukpeople.woorimap.couple.domain.InviteCode;
 public interface InviteCodQueryRepository {
 
     Optional<InviteCode> findInviteCodeByInviterId(Long inviterId);
+
+    void deleteByTwoMemberId(Long inviterId, Long receiverId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepository.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.couple.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
@@ -8,5 +9,5 @@ public interface InviteCodQueryRepository {
 
     Optional<InviteCode> findInviteCodeByInviterId(Long inviterId);
 
-    void deleteByTwoMemberId(Long inviterId, Long receiverId);
+    void deleteByInIds(List<Long> ids);
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.couple.infrastructure;
 import static com.musseukpeople.woorimap.couple.domain.QInviteCode.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
@@ -28,9 +29,9 @@ public class InviteCodQueryRepositoryImpl implements InviteCodQueryRepository {
     }
 
     @Override
-    public void deleteByTwoMemberId(Long inviterId, Long receiverId) {
+    public void deleteByInIds(List<Long> ids) {
         jpaQueryFactory.delete(inviteCode)
-            .where(inviteCode.inviterId.in(inviterId, receiverId));
+            .where(inviteCode.inviterId.in(ids));
     }
 
     private BooleanExpression inviterIdEq(Long inviterId) {

--- a/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/infrastructure/InviteCodQueryRepositoryImpl.java
@@ -27,6 +27,12 @@ public class InviteCodQueryRepositoryImpl implements InviteCodQueryRepository {
             .fetchOne());
     }
 
+    @Override
+    public void deleteByTwoMemberId(Long inviterId, Long receiverId) {
+        jpaQueryFactory.delete(inviteCode)
+            .where(inviteCode.inviterId.in(inviterId, receiverId));
+    }
+
     private BooleanExpression inviterIdEq(Long inviterId) {
         return inviteCode.inviterId.eq(inviterId);
     }

--- a/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
@@ -2,10 +2,13 @@ package com.musseukpeople.woorimap.couple.presentation;
 
 import java.time.LocalDateTime;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +18,7 @@ import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.couple.application.CoupleFacade;
+import com.musseukpeople.woorimap.couple.application.dto.request.CreateCoupleRequest;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,11 +33,21 @@ public class CoupleController {
 
     private final CoupleFacade coupleFacade;
 
+    @Operation(summary = "커플 맺기", description = "커플 맺기 API입니다.")
+    @PostMapping
+    public ResponseEntity<Void> createCouple(
+        @Valid @RequestBody CreateCoupleRequest createCoupleRequest,
+        @Login LoginMember receiver
+    ) {
+        coupleFacade.createCouple(createCoupleRequest.getCode(), receiver);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "커플 해제", description = "커플 해제 API입니다.")
     @OnlyCouple
     @DeleteMapping
     public ResponseEntity<Void> deleteCouple(@Login LoginMember member) {
-        coupleFacade.removeCouple(member.getCoupleId());
+        coupleFacade.removeCouple(member);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
@@ -34,6 +34,7 @@ public class CoupleController {
     private final CoupleFacade coupleFacade;
 
     @Operation(summary = "커플 맺기", description = "커플 맺기 API입니다.")
+    @OnlySolo
     @PostMapping
     public ResponseEntity<Void> createCouple(
         @Valid @RequestBody CreateCoupleRequest createCoupleRequest,

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
@@ -12,10 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.util.IntegrationTest;
+import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
 
 class CoupleServiceTest extends IntegrationTest {
 
+    private static final TCoupleBuilder coupleBuilder = new TCoupleBuilder();
     private static final Long COUPLE_ID = 1L;
     private static final LocalDate COUPLE_START_DATE = LocalDate.of(2022, 1, 1);
 
@@ -25,9 +29,25 @@ class CoupleServiceTest extends IntegrationTest {
     @Autowired
     private CoupleRepository coupleRepository;
 
+    @DisplayName("커플 생성 성공")
+    @Test
+    void create_success() {
+        //given
+        Member inviter = new TMemberBuilder().email("inviter1@gmail.com").build();
+        Member receiver = new TMemberBuilder().email("receiver1@gmail.com").build();
+
+        //when
+        Long coupleId = coupleService.createCouple(inviter, receiver, COUPLE_START_DATE);
+        Optional<Couple> couple = coupleRepository.findById(coupleId);
+
+        //then
+        assertThat(couple).isPresent();
+    }
+
     @BeforeEach
     void setup() {
-        coupleRepository.save(new Couple(COUPLE_ID, COUPLE_START_DATE));
+        Couple testCouple = coupleBuilder.id(COUPLE_ID).startDate(COUPLE_START_DATE).build();
+        coupleRepository.save(testCouple);
     }
 
     @DisplayName("커플 삭제 성공")

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.couple.application;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -35,9 +36,10 @@ class CoupleServiceTest extends IntegrationTest {
         //given
         Member inviter = new TMemberBuilder().email("inviter1@gmail.com").build();
         Member receiver = new TMemberBuilder().email("receiver1@gmail.com").build();
+        List<Member> members = List.of(inviter, receiver);
 
         //when
-        Long coupleId = coupleService.createCouple(inviter, receiver, COUPLE_START_DATE);
+        Long coupleId = coupleService.createCouple(members, COUPLE_START_DATE);
         Optional<Couple> couple = coupleRepository.findById(coupleId);
 
         //then

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 import com.musseukpeople.woorimap.couple.domain.InviteCode;
 import com.musseukpeople.woorimap.couple.domain.InviteCodeRepository;
+import com.musseukpeople.woorimap.couple.exception.NotFoundInviteCodeException;
 import com.musseukpeople.woorimap.util.IntegrationTest;
 
 class InviteCodeServiceTest extends IntegrationTest {
@@ -74,5 +75,32 @@ class InviteCodeServiceTest extends IntegrationTest {
 
         //then
         assertThat(inviteCode.getCode()).isEqualTo(INVITE_CODE);
+    }
+
+    @DisplayName("초대 코드로 InviterId를 가지고 올 수 있다.")
+    @Test
+    void getInviterId_success() {
+        //given
+        inviteCodeRepository.save(new InviteCode(INVITE_CODE, INVITER_ID, EXPIRE_DATE));
+
+        //when
+        Long inviterId = inviteCodeService.getInviterIdByInviteCode(INVITE_CODE);
+
+        //then
+        assertThat(inviterId).isEqualTo(INVITER_ID);
+    }
+
+    @DisplayName("초대 코드가 존재하지 않아 가져올 수 없다.")
+    @Test
+    void getInviterId_notSaved_fail() {
+        //given
+        String notSavedCode = "7894561";
+        inviteCodeRepository.save(new InviteCode(INVITE_CODE, INVITER_ID, EXPIRE_DATE));
+
+        //when
+        assertThatThrownBy(() -> inviteCodeService.getInviterIdByInviteCode(notSavedCode))
+
+            //then
+            .isInstanceOf(NotFoundInviteCodeException.class);
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/InviteCodeServiceTest.java
@@ -84,7 +84,7 @@ class InviteCodeServiceTest extends IntegrationTest {
         inviteCodeRepository.save(new InviteCode(INVITE_CODE, INVITER_ID, EXPIRE_DATE));
 
         //when
-        Long inviterId = inviteCodeService.getInviterIdByInviteCode(INVITE_CODE);
+        Long inviterId = inviteCodeService.getIdByCode(INVITE_CODE);
 
         //then
         assertThat(inviterId).isEqualTo(INVITER_ID);
@@ -98,7 +98,7 @@ class InviteCodeServiceTest extends IntegrationTest {
         inviteCodeRepository.save(new InviteCode(INVITE_CODE, INVITER_ID, EXPIRE_DATE));
 
         //when
-        assertThatThrownBy(() -> inviteCodeService.getInviterIdByInviteCode(notSavedCode))
+        assertThatThrownBy(() -> inviteCodeService.getIdByCode(notSavedCode))
 
             //then
             .isInstanceOf(NotFoundInviteCodeException.class);

--- a/src/test/java/com/musseukpeople/woorimap/couple/domain/CoupleTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/domain/CoupleTest.java
@@ -3,13 +3,22 @@ package com.musseukpeople.woorimap.couple.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+import com.musseukpeople.woorimap.member.domain.Member;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
+
 class CoupleTest {
+
+    private static final Member INVITER = new TMemberBuilder().email("inviter1@gmail.com").build();
+    private static final Member RECEIVER = new TMemberBuilder().email("receiver1@gmail.com").build();
+    private static final CoupleMembers coupleMembers = new CoupleMembers(List.of(INVITER, RECEIVER));
 
     @DisplayName("커플 생성 성공")
     @Test
@@ -18,7 +27,7 @@ class CoupleTest {
         LocalDate startDate = LocalDate.now();
 
         //when
-        Couple couple = new Couple(startDate);
+        Couple couple = new Couple(startDate, coupleMembers);
 
         //then
         System.out.println(couple.getStartDate());
@@ -35,7 +44,7 @@ class CoupleTest {
         LocalDate afterNowDate = LocalDate.now().plusDays(plusDateCount);
 
         //when
-        assertThatThrownBy(() -> new Couple(afterNowDate))
+        assertThatThrownBy(() -> new Couple(afterNowDate, coupleMembers))
 
             //then
             .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembersTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/domain/vo/CoupleMembersTest.java
@@ -1,0 +1,64 @@
+package com.musseukpeople.woorimap.couple.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.musseukpeople.woorimap.member.domain.Member;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
+
+class CoupleMembersTest {
+
+    private static final Member inviter = new TMemberBuilder().email("inviter1@gmail.com").build();
+    private static final Member receiver = new TMemberBuilder().email("receiver1@gmail.com").build();
+
+    @DisplayName("커플 멤버 컬렉션 생성 성공")
+    @Test
+    void construct_success() {
+        //given
+        List<Member> members = List.of(inviter, receiver);
+
+        //when
+        CoupleMembers coupleMembers = new CoupleMembers(members);
+
+        //then
+        assertAll(
+            () -> assertThat(coupleMembers.getMembers()).hasSize(2),
+            () -> assertThat(coupleMembers.getMembers()).usingRecursiveFieldByFieldElementComparator()
+                .isEqualTo(members)
+        );
+    }
+
+    @DisplayName("2명 미만의 멤버로 생성할 수 없다.")
+    @Test
+    void construct_underSize_2_fail() {
+        //given
+        List<Member> oneMemberList = List.of(CoupleMembersTest.inviter);
+
+        //when
+        assertThatThrownBy(() -> new CoupleMembers(oneMemberList))
+
+            //then
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("커플 인원이 2명이 아닙니다");
+    }
+
+    @DisplayName("3명 이상의 멤버로 생성할 수 없다.")
+    @Test
+    void construct_overSize_3_fail() {
+        //given
+        Member overMember = new TMemberBuilder().email("overSize@gamil.com").build();
+        List<Member> overMembers = List.of(CoupleMembersTest.inviter, receiver, overMember);
+
+        //when
+        assertThatThrownBy(() -> new CoupleMembers(overMembers))
+
+            //then
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("커플 인원이 2명이 아닙니다");
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/util/fixture/TCoupleBuilder.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/fixture/TCoupleBuilder.java
@@ -1,0 +1,38 @@
+package com.musseukpeople.woorimap.util.fixture;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+
+public class TCoupleBuilder {
+
+    private static final String INVITER_EMAIL = "inviter1@gmail.com";
+    private static final String RECEIVER_EMAIL = "receiver@gmail.com";
+    private static final TMemberBuilder memberBuilder = new TMemberBuilder();
+
+    private Long coupleId;
+    private LocalDate startDate = LocalDate.now();
+    private CoupleMembers members = new CoupleMembers(
+        List.of(memberBuilder.email(INVITER_EMAIL).build(), memberBuilder.email(RECEIVER_EMAIL).build()));
+
+    public TCoupleBuilder id(Long coupleId) {
+        this.coupleId = coupleId;
+        return this;
+    }
+
+    public TCoupleBuilder startDate(LocalDate startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    public TCoupleBuilder coupleMembers(CoupleMembers coupleMembers) {
+        this.members = coupleMembers;
+        return this;
+    }
+
+    public Couple build() {
+        return new Couple(coupleId, startDate, members);
+    }
+}


### PR DESCRIPTION
## 요약
커플 맺기 API 구현
<br><br>

## 작업 내용
- ErrorCode 추가

- CoupleFacade
  - 커플 생성 기능 구현
  
- CoupleService
  - 커플 생성 기능 구현

- InviteCodeService
  - 초대 코드 조회 구현
  - 초대 코드 삭제 구현

- Exception
  - 커플관련 예외처리 구현

- Controller
  - 커플 맺기 API 구현

- Test
  - AcceptancTest에 커플 맺기 구현
<br><br>

## 참고 사항
- 커플 맺기 이용시 초대코드 생성자의 코드를 자기자신이 해당 코드를 통해 커플 맺기를 하면 예외 발생
- 커플 맺기는 초대코드를 생성자가 아닌 다른 사용자의 코드를 통해 커플 맺기를 할 수 있다.

- AcceptanceTest 커플 맺기 사용
  - 로그인 토큰을 통해 커플 맺기를 한 후 다시 로그인_토큰을 통해서 accessToken을 사용하면 될 거 같습니다.

``` java
SignInRequest sr = new SignInRequest(....);

String accessToken = 로그인_토큰(sr);
커플_맺기(accessToken);
accessToken = 로그인_토큰(sr)
```
<br><br>
