### PR TITLE
[WOOR-149] chore: https 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ spring:
   profiles:
     active: local
 
+server:
+  forward-headers-strategy: framework
+  
 springdoc:
   swagger-ui:
     path: /api-docs


### PR DESCRIPTION
## 요약
- https 적용

<br><br>

## 작업 내용
- swagger https 적용으로 인한 `forward-headers-strategy` 전략 변경

<br><br>

## 참고 사항
- 현재 nginx를 통해 https를 적용하였습니다. nginx (443) -> spring(8080) 을 바라보는 모습입니다. 
- 인증서는 `certbot`을 이용했습니다.
- 도메인의 경우 한국 도메인을 이용하였습니다. https://dev.woorimap.p-e.kr/

<br><br>
