### PR TITLE
[WOOR-112] feat: 로그아웃 블랙리스트 등록 기능 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/application/AuthFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/AuthFacade.java
@@ -14,7 +14,6 @@ import com.musseukpeople.woorimap.auth.application.dto.response.LoginResponseDto
 import com.musseukpeople.woorimap.auth.domain.RefreshToken;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
-import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.member.application.MemberService;
 import com.musseukpeople.woorimap.member.domain.Member;
@@ -56,7 +55,6 @@ public class AuthFacade {
 
     public AccessTokenResponse refreshAccessToken(String accessToken, String refreshToken) {
         validateRefreshToken(refreshToken);
-        validateBlackList(accessToken);
 
         Claims claims = jwtProvider.getClaims(accessToken);
         RefreshToken findRefreshToken = getRefreshToken(claims);
@@ -65,14 +63,7 @@ public class AuthFacade {
         }
 
         String newAccessToken = createNewAccessToken(claims);
-        registerBlackList(accessToken);
         return new AccessTokenResponse(newAccessToken);
-    }
-
-    private void validateBlackList(String accessToken) {
-        if (blackListService.isBlackList(accessToken)) {
-            throw new UnauthorizedException(ErrorCode.BLACKLIST_TOKEN);
-        }
     }
 
     private void registerBlackList(String accessToken) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/AuthFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/AuthFacade.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AuthService {
+public class AuthFacade {
 
     private final MemberService memberService;
     private final RefreshTokenService refreshTokenService;

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/BlackListService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/BlackListService.java
@@ -1,0 +1,28 @@
+package com.musseukpeople.woorimap.auth.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
+import com.musseukpeople.woorimap.auth.domain.BlackList;
+import com.musseukpeople.woorimap.auth.domain.BlackListRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlackListService {
+
+    private final BlackListRepository blackListRepository;
+
+    @Transactional
+    public void saveBlackList(TokenDto tokenDto) {
+        BlackList blackList = new BlackList(tokenDto.getValue(), tokenDto.getExpiredTime());
+        blackListRepository.save(blackList);
+    }
+
+    public boolean isBlackList(String accessToken) {
+        return blackListRepository.existsById(accessToken);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.auth.application;
 
+import java.util.Date;
+
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 
 import io.jsonwebtoken.Claims;
@@ -11,6 +13,8 @@ public interface JwtProvider {
     TokenDto createRefreshToken();
 
     boolean validateToken(String token);
+
+    Date getExpiredDate(String token);
 
     Claims getClaims(String token);
 

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/RefreshTokenService.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
-import com.musseukpeople.woorimap.auth.domain.Token;
-import com.musseukpeople.woorimap.auth.domain.TokenRepository;
+import com.musseukpeople.woorimap.auth.domain.RefreshToken;
+import com.musseukpeople.woorimap.auth.domain.RefreshTokenRepository;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
@@ -14,23 +14,23 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class TokenService {
+public class RefreshTokenService {
 
-    private final TokenRepository tokenRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public void saveToken(String memberId, TokenDto tokenDto) {
-        Token token = new Token(memberId, tokenDto.getValue(), tokenDto.getExpiredTime());
-        tokenRepository.save(token);
+        RefreshToken refreshToken = new RefreshToken(memberId, tokenDto.getValue(), tokenDto.getExpiredTime());
+        refreshTokenRepository.save(refreshToken);
     }
 
     @Transactional
     public void removeByMemberId(String memberId) {
-        tokenRepository.deleteById(memberId);
+        refreshTokenRepository.deleteById(memberId);
     }
 
-    public Token getTokenByMemberId(String memberId) {
-        return tokenRepository.findById(memberId)
+    public RefreshToken getTokenByMemberId(String memberId) {
+        return refreshTokenRepository.findById(memberId)
             .orElseThrow(() -> new InvalidTokenException(null, ErrorCode.INVALID_TOKEN));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/BlackList.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/BlackList.java
@@ -1,0 +1,28 @@
+package com.musseukpeople.woorimap.auth.domain;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@RedisHash("blackList")
+public class BlackList {
+
+    @Id
+    private String accessToken;
+
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private long expiredTime;
+
+    public BlackList(String accessToken, long expiredTime) {
+        this.accessToken = accessToken;
+        this.expiredTime = expiredTime;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/BlackListRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/BlackListRepository.java
@@ -1,0 +1,6 @@
+package com.musseukpeople.woorimap.auth.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface BlackListRepository extends CrudRepository<BlackList, String> {
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/RefreshToken.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/RefreshToken.java
@@ -13,23 +13,23 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@RedisHash("token")
-public class Token {
+@RedisHash("refreshToken")
+public class RefreshToken {
 
     @Id
     private String id;
-    private String refreshToken;
+    private String value;
 
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private long expiredTime;
 
-    public Token(String id, String refreshToken, long expiredTime) {
+    public RefreshToken(String id, String value, long expiredTime) {
         this.id = id;
-        this.refreshToken = refreshToken;
+        this.value = value;
         this.expiredTime = expiredTime;
     }
 
     public boolean isNotSame(String refreshToken) {
-        return !Objects.equals(this.refreshToken, refreshToken);
+        return !Objects.equals(this.value, refreshToken);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/RefreshTokenRepository.java
@@ -2,5 +2,5 @@ package com.musseukpeople.woorimap.auth.domain;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface TokenRepository extends CrudRepository<Token, String> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/domain/login/LoginMember.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/domain/login/LoginMember.java
@@ -10,19 +10,21 @@ public class LoginMember {
     private Long id;
     private Long coupleId;
     private Authority authority;
+    private String accessToken;
 
     public LoginMember(Authority authority) {
-        this(null, null, authority);
+        this(null, null, authority, null);
     }
 
-    public LoginMember(Long id, Long coupleId) {
-        this(id, coupleId, coupleId != null ? COUPLE : SOLO);
+    public LoginMember(Long id, Long coupleId, String accessToken) {
+        this(id, coupleId, coupleId != null ? COUPLE : SOLO, accessToken);
     }
 
-    private LoginMember(Long id, Long coupleId, Authority authority) {
+    private LoginMember(Long id, Long coupleId, Authority authority, String accessToken) {
         this.id = id;
         this.coupleId = coupleId;
         this.authority = authority;
+        this.accessToken = accessToken;
     }
 
     public boolean isAnonymous() {

--- a/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProvider.java
@@ -79,6 +79,11 @@ public class JwtTokenProvider implements JwtProvider {
     }
 
     @Override
+    public Date getExpiredDate(String token) {
+        return getClaims(token).getExpiration();
+    }
+
+    @Override
     public Claims getClaims(String token) {
         try {
             return getClaimsJws(token).getBody();

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -26,6 +26,7 @@ import com.musseukpeople.woorimap.auth.presentation.util.CookieUtil;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -55,6 +56,7 @@ public class AuthController {
     }
 
     @Operation(summary = "엑세스 토큰 재발급", description = "엑세스 토큰을 재발급 받습니다.")
+    @SecurityRequirement(name = "bearer")
     @PostMapping("/token")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(@RequestTokens JwtToken jwtToken) {
         AccessTokenResponse accessToken = authService.refreshAccessToken(

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.musseukpeople.woorimap.auth.aop.LoginRequired;
-import com.musseukpeople.woorimap.auth.application.AuthService;
+import com.musseukpeople.woorimap.auth.application.AuthFacade;
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
@@ -36,13 +36,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthService authService;
+    private final AuthFacade authFacade;
 
     @Operation(summary = "로그인", description = "로그인 API입니다.")
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<LoginResponse>> signIn(@Valid @RequestBody SignInRequest signInRequest,
                                                              HttpServletResponse response) {
-        LoginResponseDto loginResponseDto = authService.login(signInRequest);
+        LoginResponseDto loginResponseDto = authFacade.login(signInRequest);
         setTokenCookie(response, loginResponseDto.getRefreshToken());
         return ResponseEntity.ok(new ApiResponse<>(LoginResponse.from(loginResponseDto)));
     }
@@ -51,7 +51,7 @@ public class AuthController {
     @LoginRequired
     @PostMapping("/signout")
     public ResponseEntity<Void> signout(@Login LoginMember loginMember) {
-        authService.logout(loginMember);
+        authFacade.logout(loginMember);
         return ResponseEntity.noContent().build();
     }
 
@@ -59,7 +59,7 @@ public class AuthController {
     @SecurityRequirement(name = "bearer")
     @PostMapping("/token")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshAccessToken(@RequestTokens JwtToken jwtToken) {
-        AccessTokenResponse accessToken = authService.refreshAccessToken(
+        AccessTokenResponse accessToken = authFacade.refreshAccessToken(
             jwtToken.getAccessToken(),
             jwtToken.getRefreshToken()
         );

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -50,7 +50,7 @@ public class AuthController {
     @LoginRequired
     @PostMapping("/signout")
     public ResponseEntity<Void> signout(@Login LoginMember loginMember) {
-        authService.logout(loginMember.getId());
+        authService.logout(loginMember);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthInterceptor.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.google.common.base.Strings;
 import com.musseukpeople.woorimap.auth.aop.LoginRequired;
+import com.musseukpeople.woorimap.auth.application.BlackListService;
 import com.musseukpeople.woorimap.auth.application.JwtProvider;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
 import com.musseukpeople.woorimap.auth.exception.UnauthorizedException;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthInterceptor implements HandlerInterceptor {
 
     private final JwtProvider jwtProvider;
+    private final BlackListService blackListService;
 
     @Override
     public boolean preHandle(HttpServletRequest request,
@@ -34,7 +36,14 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         String accessToken = AuthorizationExtractor.extract(request);
         validateAccessToken(accessToken);
+        validateBlackList(accessToken);
         return true;
+    }
+
+    private void validateBlackList(String accessToken) {
+        if (blackListService.isBlackList(accessToken)) {
+            throw new UnauthorizedException(ErrorCode.BLACKLIST_TOKEN);
+        }
     }
 
     private boolean isNotLoginRequired(Object handler) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/fake/FakeAuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/fake/FakeAuthController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.musseukpeople.woorimap.auth.application.JwtProvider;
-import com.musseukpeople.woorimap.auth.application.TokenService;
+import com.musseukpeople.woorimap.auth.application.RefreshTokenService;
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.LoginMemberResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.LoginResponseDto;
-import com.musseukpeople.woorimap.auth.domain.Token;
+import com.musseukpeople.woorimap.auth.domain.RefreshToken;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
 import com.musseukpeople.woorimap.auth.infrastructure.AuthorizationExtractor;
 import com.musseukpeople.woorimap.auth.infrastructure.JwtTokenProvider;
@@ -65,14 +65,15 @@ public class FakeAuthController {
     @Transactional(readOnly = true)
     static class FakeAuthService {
         private final MemberService memberService;
-        private final TokenService tokenService;
+        private final RefreshTokenService refreshTokenService;
         private final PasswordEncoder passwordEncoder;
         private JwtProvider jwtProvider;
 
-        public FakeAuthService(MemberService memberService, TokenService tokenService, PasswordEncoder passwordEncoder,
+        public FakeAuthService(MemberService memberService, RefreshTokenService refreshTokenService,
+                               PasswordEncoder passwordEncoder,
                                @Value("${jwt.issuer}") String issuer, @Value("${jwt.secret-key}") String secretKey) {
             this.memberService = memberService;
-            this.tokenService = tokenService;
+            this.refreshTokenService = refreshTokenService;
             this.passwordEncoder = passwordEncoder;
             this.jwtProvider = new JwtTokenProvider(issuer, secretKey, 10_000, 30_000);
         }
@@ -87,7 +88,7 @@ public class FakeAuthController {
             TokenDto accessToken = jwtProvider.createAccessToken(memberId, coupleId);
             TokenDto refreshToken = jwtProvider.createRefreshToken();
 
-            tokenService.saveToken(memberId, refreshToken);
+            refreshTokenService.saveToken(memberId, refreshToken);
             return new LoginResponseDto(accessToken, refreshToken, LoginMemberResponse.from(member));
         }
 
@@ -98,8 +99,8 @@ public class FakeAuthController {
             }
 
             Claims claims = jwtProvider.getClaims(accessToken);
-            Token findRefreshToken = getRefreshToken(claims);
-            if (findRefreshToken.isNotSame(refreshToken)) {
+            RefreshToken findRefreshRefreshToken = getRefreshToken(claims);
+            if (findRefreshRefreshToken.isNotSame(refreshToken)) {
                 throw new InvalidTokenException(refreshToken, ErrorCode.INVALID_TOKEN);
             }
 
@@ -107,9 +108,9 @@ public class FakeAuthController {
             return new AccessTokenResponse(newAccessToken);
         }
 
-        private Token getRefreshToken(Claims claims) {
+        private RefreshToken getRefreshToken(Claims claims) {
             String memberId = claims.getSubject();
-            return tokenService.getTokenByMemberId(memberId);
+            return refreshTokenService.getTokenByMemberId(memberId);
         }
 
         private String createNewAccessToken(Claims claims) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/resolver/AuthArgumentResolver.java
@@ -50,7 +50,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         Claims claims = jwtProvider.getClaims(accessToken);
         Long id = convertMemberId(accessToken, claims);
         Long coupleId = convertCoupleId(accessToken, claims);
-        return new LoginMember(id, coupleId);
+        return new LoginMember(id, coupleId, accessToken);
     }
 
     private Long convertMemberId(String token, Claims claims) {

--- a/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/WebConfig.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.musseukpeople.woorimap.auth.aop.MemberAuthorityContext;
+import com.musseukpeople.woorimap.auth.application.BlackListService;
 import com.musseukpeople.woorimap.auth.application.JwtProvider;
 import com.musseukpeople.woorimap.auth.presentation.AuthInterceptor;
 import com.musseukpeople.woorimap.auth.presentation.resolver.AuthArgumentResolver;
@@ -24,6 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
     private static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";
 
     private final JwtProvider jwtProvider;
+    private final BlackListService blackListService;
     private final MemberAuthorityContext memberAuthorityContext;
 
     @Override
@@ -38,7 +40,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthInterceptor(jwtProvider));
+        registry.addInterceptor(new AuthInterceptor(jwtProvider, blackListService));
     }
 
     @Override

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // Auth
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
     NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다."),
+    BLACKLIST_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "허용되지 않는 토큰입니다."),
 
     // Couple
     NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다."),

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -100,13 +100,11 @@ class AuthControllerTest extends AcceptanceTest {
     @Test
     void logout_blackList_success() throws Exception {
         // given
-        MockHttpServletResponse loginResponse = 로그인(new SignInRequest("woorimap@gmail.com", "!Hwan123"));
-        String accessToken = getAccessToken(loginResponse);
-        String refreshToken = getRefreshToken(loginResponse);
-        로그아웃("Bearer" + accessToken);
+        String accessToken = 로그인_토큰(new SignInRequest("woorimap@gmail.com", "!Hwan123"));
+        로그아웃(accessToken);
 
         // when
-        MockHttpServletResponse response = 토큰_재발급_요청(accessToken, refreshToken);
+        MockHttpServletResponse response = 로그아웃(accessToken);
 
         // then
         ErrorResponse errorResponse = getErrorResponse(response);

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -103,7 +103,7 @@ class AuthControllerTest extends AcceptanceTest {
         MockHttpServletResponse loginResponse = 로그인(new SignInRequest("woorimap@gmail.com", "!Hwan123"));
         String accessToken = getAccessToken(loginResponse);
         String refreshToken = getRefreshToken(loginResponse);
-        로그아웃(accessToken);
+        로그아웃("Bearer" + accessToken);
 
         // when
         MockHttpServletResponse response = 토큰_재발급_요청(accessToken, refreshToken);
@@ -167,7 +167,7 @@ class AuthControllerTest extends AcceptanceTest {
 
     private MockHttpServletResponse 로그아웃(String accessToken) throws Exception {
         return mockMvc.perform(post("/api/auth/signout")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .header(HttpHeaders.AUTHORIZATION, accessToken))
             .andReturn().getResponse();
     }
 

--- a/src/test/java/com/musseukpeople/woorimap/auth/application/AuthFacadeTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/application/AuthFacadeTest.java
@@ -17,12 +17,12 @@ import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.member.exception.LoginFailedException;
 import com.musseukpeople.woorimap.util.IntegrationTest;
 
-class AuthServiceTest extends IntegrationTest {
+class AuthFacadeTest extends IntegrationTest {
 
     private final String email = "woorimap@gmail.com";
     private final String password = "!Hwan123";
     @Autowired
-    private AuthService authService;
+    private AuthFacade authFacade;
 
     @Autowired
     private MemberService memberService;
@@ -39,7 +39,7 @@ class AuthServiceTest extends IntegrationTest {
         SignInRequest signInRequest = new SignInRequest(email, password);
 
         // when
-        LoginResponseDto loginResponseDto = authService.login(signInRequest);
+        LoginResponseDto loginResponseDto = authFacade.login(signInRequest);
 
         // then
         assertAll(
@@ -57,7 +57,7 @@ class AuthServiceTest extends IntegrationTest {
 
         // when
         // then
-        assertThatThrownBy(() -> authService.login(signInRequest))
+        assertThatThrownBy(() -> authFacade.login(signInRequest))
             .isInstanceOf(LoginFailedException.class)
             .hasMessageContaining("이메일 또는 비밀번호가 일치하지 않습니다.");
     }
@@ -71,7 +71,7 @@ class AuthServiceTest extends IntegrationTest {
 
         // when
         // then
-        assertThatThrownBy(() -> authService.login(signInRequest))
+        assertThatThrownBy(() -> authFacade.login(signInRequest))
             .isInstanceOf(LoginFailedException.class)
             .hasMessageContaining("이메일 또는 비밀번호가 일치하지 않습니다");
     }
@@ -85,7 +85,7 @@ class AuthServiceTest extends IntegrationTest {
         String refreshToken = loginResponseDto.getRefreshToken().getValue();
 
         // when
-        AccessTokenResponse accessTokenResponse = authService.refreshAccessToken(accessToken, refreshToken);
+        AccessTokenResponse accessTokenResponse = authFacade.refreshAccessToken(accessToken, refreshToken);
 
         // then
         assertThat(accessTokenResponse.getAccessToken()).isNotNull();
@@ -101,7 +101,7 @@ class AuthServiceTest extends IntegrationTest {
 
         // when
         // then
-        assertThatThrownBy(() -> authService.refreshAccessToken(invalidAccessToken, refreshToken))
+        assertThatThrownBy(() -> authFacade.refreshAccessToken(invalidAccessToken, refreshToken))
             .isInstanceOf(InvalidTokenException.class)
             .hasMessageContaining("유효하지 않은 토큰입니다.");
     }
@@ -116,12 +116,12 @@ class AuthServiceTest extends IntegrationTest {
 
         // when
         // then
-        assertThatThrownBy(() -> authService.refreshAccessToken(accessToken, invalidRefreshToken))
+        assertThatThrownBy(() -> authFacade.refreshAccessToken(accessToken, invalidRefreshToken))
             .isInstanceOf(InvalidTokenException.class)
             .hasMessageContaining("유효하지 않은 토큰입니다.");
     }
 
     private LoginResponseDto login(String email, String password) {
-        return authService.login(new SignInRequest(email, password));
+        return authFacade.login(new SignInRequest(email, password));
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/auth/application/BlackListServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/application/BlackListServiceTest.java
@@ -1,0 +1,62 @@
+package com.musseukpeople.woorimap.auth.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
+import com.musseukpeople.woorimap.auth.domain.BlackListRepository;
+import com.musseukpeople.woorimap.util.IntegrationTest;
+
+class BlackListServiceTest extends IntegrationTest {
+
+    @Autowired
+    private BlackListService blackListService;
+
+    @Autowired
+    private BlackListRepository blackListRepository;
+
+    @DisplayName("블랙 리스트 토큰 저장 성공")
+    @Test
+    void saveBlackList_success() {
+        // given
+        String accessToken = "accessToken";
+        long expiredTime = 1000L;
+
+        // when
+        blackListService.saveBlackList(new TokenDto(accessToken, expiredTime));
+
+        // then
+        assertThat(blackListRepository.findById(accessToken)).isNotEmpty();
+    }
+
+    @DisplayName("블랙 리스트 확인 성공")
+    @Test
+    void isBlackList_success() {
+        // given
+        String accessToken = "accessToken";
+        long expiredTime = 1000L;
+        blackListService.saveBlackList(new TokenDto(accessToken, expiredTime));
+
+        // when
+        boolean result = blackListService.isBlackList(accessToken);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("블랙 리스트가 아님으로 인한 실패")
+    @Test
+    void isBlackList_notBlackList_fail() {
+        // given
+        String accessToken = "notBlackList";
+
+        // when
+        boolean result = blackListService.isBlackList(accessToken);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProviderTest.java
@@ -3,6 +3,8 @@ package com.musseukpeople.woorimap.auth.infrastructure;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Date;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -99,5 +101,18 @@ class JwtTokenProviderTest {
 
         // then
         assertThat(result).isFalse();
+    }
+
+    @DisplayName("토큰의 유효 시간 추출 성공")
+    @Test
+    void getExpiredDate_success() {
+        // given
+        String accessToken = PROVIDER.createAccessToken("1", 1L).getValue();
+
+        // when
+        Date expiredDate = PROVIDER.getExpiredDate(accessToken);
+
+        // then
+        assertThat(expiredDate).isAfter(new Date());
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/util/DatabaseCleanup.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/DatabaseCleanup.java
@@ -8,7 +8,10 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,9 @@ public class DatabaseCleanup implements InitializingBean {
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
 
     private List<String> tableNames;
 
@@ -45,5 +51,12 @@ public class DatabaseCleanup implements InitializingBean {
         }
 
         entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1;").executeUpdate();
+        redisCleanUp();
+    }
+
+    private void redisCleanUp() {
+        RedisConnection connection = redisConnectionFactory.getConnection();
+        connection.execute("flushall");
+        connection.close();
     }
 }


### PR DESCRIPTION
## 요약
- 로그아웃 블랙리스트 등록 기능 구현

<br><br>

## 작업 내용
- 블랙리스트 기능을 위해 accessToken을 LoginMember가 가지도록 구현 (e618ea7b255f9e3e6b35a9ba4b5afe55bbfb3eaf) 
- Token -> RefreshToken 네이밍 변경 (00d67f02b6ea6461c3991f049c2b35a681a7606c) 
- 블랙리스트 기능 구현 (36f42ce89d3d302b3e00cd492fe83eb18876d23b)
- 로그아웃 시 accessToken 블랙리스트 등록 (0e6c278bc00887b02b99f57636930964895062f0) 
  - 로그아웃시 해당 토큰을 블랙리스트로 설정하여 탈취를 당하더라도 서비스 이용을 못하게 합니다. 
  - 해당 토큰은 accessToken의 만료기한까지 레디스에 남아있게 됩니다. 
- 인터셉터에서 블랙리스트 토큰인지 확인 (2fe7cbb904a43c2c7db0f7b0d931bcb148d7f8e4)

<br><br>

## 참고 사항
- 토큰의 장점이 디비와의 통신이 작다는 점인데 블랙리스트를 구현하니 보안은 좋아졌지만 디비와의 통신이 무조건 필요하네요. 
- 토큰 저장소를 레디스로 했기 때문에 휘발성이나 속도 면에서는 좋지만 토큰의 장점이 없어지는? 느낌이네요 😂
- 이럴거면 세션을 써야하나 싶기도 하고 어떻게 생각하시나요?

<br><br>
