### PR TITLE
[WOOR-55] feat: 회원 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
@@ -2,6 +2,8 @@ package com.musseukpeople.woorimap.member.application.dto.response;
 
 import java.time.LocalDate;
 
+import com.musseukpeople.woorimap.member.domain.Member;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,5 +25,25 @@ public class MemberResponse {
         this.coupleNickName = coupleNickName;
         this.coupleStartingDate = coupleStartingDate;
         this.isCouple = isCouple;
+    }
+
+    public static MemberResponse createSoloMemberResponse(Member member) {
+        return new MemberResponse(
+            member.getImageUrl(),
+            member.getNickName().getValue(),
+            null,
+            null,
+            member.isCouple()
+        );
+    }
+
+    public static MemberResponse createCoupleMemberResponse(Member member, Member opponentMember) {
+        return new MemberResponse(
+            member.getImageUrl(),
+            member.getNickName().getValue(),
+            opponentMember.getNickName().getValue(),
+            member.getCouple().getStartDate(),
+            member.isCouple()
+        );
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
@@ -1,0 +1,27 @@
+package com.musseukpeople.woorimap.member.application.dto.response;
+
+import java.time.LocalDate;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberResponse {
+
+    private String imageUrl;
+    private String nickName;
+    private String coupleNickName;
+    private LocalDate coupleStartingDate;
+    private boolean isCouple;
+
+    public MemberResponse(String imageUrl, String nickName, String coupleNickName, LocalDate coupleStartingDate,
+                          boolean isCouple) {
+        this.imageUrl = imageUrl;
+        this.nickName = nickName;
+        this.coupleNickName = coupleNickName;
+        this.coupleStartingDate = coupleStartingDate;
+        this.isCouple = isCouple;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import com.musseukpeople.woorimap.member.domain.Member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberResponse {
 
+    @Schema(description = "프로필 이미지 url")
     private String imageUrl;
+
+    @Schema(description = "닉네임")
     private String nickName;
+
+    @Schema(description = "커플 상대방 닉네임", nullable = true)
     private String coupleNickName;
+
+    @Schema(description = "커플 시작 날짜", nullable = true)
     private LocalDate coupleStartingDate;
+
+    @Schema(description = "커플 유무")
     private boolean isCouple;
 
     public MemberResponse(String imageUrl, String nickName, String coupleNickName, LocalDate coupleStartingDate,

--- a/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/domain/MemberRepository.java
@@ -11,8 +11,14 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmailValue(String email);
 
+    @Query("SELECT m FROM Member m LEFT JOIN FETCH m.couple WHERE m.id = :id")
+    Optional<Member> findWithCoupleById(@Param("id") Long id);
+
     @Query("SELECT m FROM Member m LEFT JOIN FETCH m.couple WHERE m.email.value = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
+
+    @Query("SELECT m FROM Member m WHERE m.couple.id = :coupleId AND m.id <> :id")
+    Optional<Member> findOpponentMember(@Param("id") Long id, @Param("coupleId") Long coupleId);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Member m SET m.couple = null WHERE m.couple.id = :coupleId")

--- a/src/main/java/com/musseukpeople/woorimap/member/domain/vo/Password.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/domain/vo/Password.java
@@ -17,8 +17,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Password {
 
     private static final String PASSWORD_FORMAT_REGEX = "((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[\\W])).*";

--- a/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
@@ -39,9 +39,11 @@ public class MemberController {
     }
 
     @Operation(summary = "멤버 정보 확인", description = "멤버 정보 확인 API입니다.")
+    @LoginRequired
     @GetMapping
     public ResponseEntity<ApiResponse<MemberResponse>> showMember(@Login LoginMember loginMember) {
-        return ResponseEntity.ok().build();
+        MemberResponse memberResponse = memberService.getMemberResponseById(loginMember.getId());
+        return ResponseEntity.ok(new ApiResponse<>(memberResponse));
     }
 
     @Operation(summary = "멤버 회원 탈퇴", description = "멤버 회원 탈퇴 API입니다.")

--- a/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/presentation/MemberController.java
@@ -5,6 +5,7 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.musseukpeople.woorimap.auth.aop.LoginRequired;
 import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.member.application.MemberService;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +36,12 @@ public class MemberController {
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignupRequest signupRequest) {
         memberService.createMember(signupRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "멤버 정보 확인", description = "멤버 정보 확인 API입니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<MemberResponse>> showMember(@Login LoginMember loginMember) {
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "멤버 회원 탈퇴", description = "멤버 회원 탈퇴 API입니다.")

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:test;MODE=MYSQL
+    url: jdbc:h2:mem:test;MODE=MYSQL;DB_CLOSE_ON_EXIT=FALSE
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -67,7 +67,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    @DisplayName("솔로 회원 정보 성공")
+    @DisplayName("솔로 회원 정보 조회 성공")
     @Test
     void showMember_solo_success() throws Exception {
         // given
@@ -77,16 +77,41 @@ class MemberAcceptanceTest extends AcceptanceTest {
         String accessToken = 회원가입_토큰(new SignupRequest(email, password, nickName));
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(get("/api/members")
+        MockHttpServletResponse response = 회원_정보_조회(accessToken);
+
+        // then
+        MemberResponse memberResponse = getResponseObject(response, MemberResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(memberResponse.isCouple()).isFalse()
+        );
+    }
+
+    @DisplayName("커플 회원 정보 조회 성공")
+    @Test
+    void showMember_couple_success() throws Exception {
+        // given
+        String email = "test@gmail.com";
+        String password = "!Hwan1234";
+        String nickName = "hwan";
+        String accessToken = 회원가입_토큰(new SignupRequest(email, password, nickName));
+        String coupleAccessToken = 커플_맺기_토큰(accessToken);
+
+        // when
+        MockHttpServletResponse response = 회원_정보_조회(coupleAccessToken);
+
+        // then
+        MemberResponse memberResponse = getResponseObject(response, MemberResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(memberResponse.getCoupleNickName()).isNotNull()
+        );
+    }
+
+    private MockHttpServletResponse 회원_정보_조회(String accessToken) throws Exception {
+        return mockMvc.perform(get("/api/members")
                 .header(HttpHeaders.AUTHORIZATION, accessToken))
             .andDo(print())
             .andReturn().getResponse();
-
-        // then
-        MemberResponse member = getResponseObject(response, MemberResponse.class);
-        assertAll(
-            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(member.isCouple()).isFalse()
-        );
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.member.acceptance;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
 
 class MemberAcceptanceTest extends AcceptanceTest {
@@ -63,5 +65,28 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("솔로 회원 정보 성공")
+    @Test
+    void showMember_solo_success() throws Exception {
+        // given
+        String email = "test@gmail.com";
+        String password = "!Hwan1234";
+        String nickName = "hwan";
+        String accessToken = 회원가입_토큰(new SignupRequest(email, password, nickName));
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(get("/api/members")
+                .header(HttpHeaders.AUTHORIZATION, accessToken))
+            .andDo(print())
+            .andReturn().getResponse();
+
+        // then
+        MemberResponse member = getResponseObject(response, MemberResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(member.isCouple()).isFalse()
+        );
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/member/application/MemberServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/application/MemberServiceTest.java
@@ -1,21 +1,27 @@
 package com.musseukpeople.woorimap.member.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.AfterEach;
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
 import com.musseukpeople.woorimap.member.exception.DuplicateEmailException;
 import com.musseukpeople.woorimap.member.exception.LoginFailedException;
+import com.musseukpeople.woorimap.util.IntegrationTest;
+import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
 
-@SpringBootTest
-class MemberServiceTest {
+class MemberServiceTest extends IntegrationTest {
 
     @Autowired
     private MemberService memberService;
@@ -23,10 +29,8 @@ class MemberServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @AfterEach
-    void tearDown() {
-        memberRepository.deleteAllInBatch();
-    }
+    @Autowired
+    private CoupleRepository coupleRepository;
 
     @DisplayName("회원 생성 성공")
     @Test
@@ -80,5 +84,43 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.getMemberByEmail("tt@gmail.com"))
             .isInstanceOf(LoginFailedException.class)
             .hasMessageContaining("이메일 또는 비밀번호가 일치하지 않습니다.");
+    }
+
+    @DisplayName("회원 정보 조회 성공 - 솔로")
+    @Test
+    void getMemberResponse_solo_success() {
+        // given
+        Member member = new TMemberBuilder().email("test@gmail.com").build();
+        Long id = memberRepository.save(member).getId();
+
+        // when
+        MemberResponse memberResponse = memberService.getMemberResponseById(id);
+
+        // then
+        assertAll(
+            () -> assertThat(memberResponse.getCoupleNickName()).isNull(),
+            () -> assertThat(memberResponse.getCoupleStartingDate()).isNull()
+        );
+    }
+
+    @DisplayName("회원 정보 조회 성공 - 커플")
+    @Test
+    void getMemberResponse_couple_success() {
+        // given
+        Couple couple = new TCoupleBuilder().build();
+        coupleRepository.save(couple);
+        Member member = new TMemberBuilder().email("test@gmail.com").couple(couple).build();
+        Member opponentMember = new TMemberBuilder().email("oppent@gmail.com").couple(couple).build();
+        Long id = memberRepository.save(member).getId();
+        memberRepository.save(opponentMember);
+
+        // when
+        MemberResponse memberResponse = memberService.getMemberResponseById(id);
+
+        // then
+        assertAll(
+            () -> assertThat(memberResponse.getCoupleNickName()).isEqualTo(opponentMember.getNickName().getValue()),
+            () -> assertThat(memberResponse.getCoupleStartingDate()).isEqualTo(LocalDate.now())
+        );
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/domain/MemberRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.musseukpeople.woorimap.member.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+import com.musseukpeople.woorimap.util.RepositoryTest;
+import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
+
+@RepositoryTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CoupleRepository coupleRepository;
+
+    @DisplayName("커플일 시 커플 멤버 조회 성공")
+    @Test
+    void findOpponentMember_success() {
+        // given
+        Member member = new TMemberBuilder().build();
+        Member opponentMember = new TMemberBuilder().email("opponentMember@gmail.com").build();
+        Long id = memberRepository.save(member).getId();
+        memberRepository.save(opponentMember);
+
+        Couple couple = new TCoupleBuilder().coupleMembers(new CoupleMembers(List.of(member, opponentMember))).build();
+        Long coupleId = coupleRepository.save(couple).getId();
+
+        // when
+        Member findOpponentMember = memberRepository.findOpponentMember(id, coupleId).get();
+
+        // then
+        assertThat(findOpponentMember).usingRecursiveComparison()
+            .ignoringFields("id")
+            .isEqualTo(opponentMember);
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/util/fixture/TMemberBuilder.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/fixture/TMemberBuilder.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.util.fixture;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.vo.Email;
 import com.musseukpeople.woorimap.member.domain.vo.NickName;
@@ -15,6 +16,7 @@ public class TMemberBuilder {
     private Password password = Password.encryptPassword(PASSWORD_ENCODER, "!Test1234");
     private NickName nickName = new NickName("test");
     private String imageUrl = "test";
+    private Couple couple = null;
 
     public TMemberBuilder email(String email) {
         this.email = new Email(email);
@@ -36,13 +38,20 @@ public class TMemberBuilder {
         return this;
     }
 
+    public TMemberBuilder couple(Couple couple) {
+        this.couple = couple;
+        return this;
+    }
+
     public Member build() {
-        return Member.builder()
+        Member member = Member.builder()
             .email(email)
             .password(password)
             .nickName(nickName)
             .imageUrl(imageUrl)
             .build();
+        member.changeCouple(couple);
+        return member;
     }
 
 }


### PR DESCRIPTION
## 요약
- 멤버 정보 조회 API 구현 

<br><br>

## 작업 내용
- 멤버 정보 조회 쿼리 구현 (4391c2ad9d32640a797a8a287ebd5f1d13a1d3aa) 
  - 커플에게 묻지 않고 레포로 바로 쿼리날리는 데 커플에게 물어봐야할 것 같기도 하고 고민이 됩니다. 의견부탁드립니다 🤔
- 멤버 정보 조회 기능 구현 (  ee796ee1e3e17d9cbedb2e429fbc8d49adde1a3b) 
  - 멤버 조회 이후 커플이면 상대방 멤버 조회하고 아닐 경우 null로 반환하게 됩니다. 

<br><br>

## 참고 사항
- DTO의 경우 일단 API 스펙에 쓰여져 있는대로 구현하였는 데 따로 구분해서 주는 것이 프론트분들이 편할 경우 변경하겠습니다!

<br><br>
