### PR TITLE
[WOOR-72] feat: 커플 수정 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleFacade.java
@@ -12,6 +12,7 @@ import com.musseukpeople.woorimap.auth.application.JwtProvider;
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
+import com.musseukpeople.woorimap.couple.application.dto.response.CoupleEditResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.CoupleMemeberResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.CoupleResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
@@ -64,6 +65,11 @@ public class CoupleFacade {
         CoupleMemeberResponse coupleYourResponse = CoupleMemeberResponse.from(couple.getOpponentMember(memberId));
 
         return new CoupleResponse(startDate, coupleMemeberResponse, coupleYourResponse);
+    }
+
+    @Transactional
+    public CoupleEditResponse modifyCouple(Long coupleId, LocalDate modifyDate) {
+        return coupleService.modifyCouple(coupleId, modifyDate);
     }
 
     @Transactional

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/CoupleService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
+import com.musseukpeople.woorimap.couple.application.dto.response.CoupleEditResponse;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
@@ -39,5 +40,15 @@ public class CoupleService {
             .orElseThrow(
                 () -> new NotFoundCoupleException(ErrorCode.NOT_FOUND_COUPLE, coupleId)
             );
+    }
+
+    @Transactional
+    public CoupleEditResponse modifyCouple(Long coupleId, LocalDate modifyDate) {
+        Couple couple = coupleRepository.findById(coupleId).orElseThrow(
+            () -> new NotFoundCoupleException(ErrorCode.NOT_FOUND_COUPLE, coupleId)
+        );
+        couple.changStartDate(modifyDate);
+
+        return new CoupleEditResponse(couple.getStartDate());
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/dto/request/EditCoupleRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/dto/request/EditCoupleRequest.java
@@ -1,0 +1,23 @@
+package com.musseukpeople.woorimap.couple.application.dto.request;
+
+import java.time.LocalDate;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EditCoupleRequest {
+
+    @Schema(description = "수정할 날짜")
+    @NotNull(message = "수정 날짜가 없습니다")
+    private LocalDate editDate;
+
+    public EditCoupleRequest(LocalDate editDate) {
+        this.editDate = editDate;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/dto/response/CoupleEditResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/dto/response/CoupleEditResponse.java
@@ -2,6 +2,7 @@ package com.musseukpeople.woorimap.couple.application.dto.response;
 
 import java.time.LocalDate;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CoupleEditResponse {
 
+    @Schema(description = "수정된 날짜")
     private LocalDate startDate;
 
     public CoupleEditResponse(LocalDate startDate) {

--- a/src/main/java/com/musseukpeople/woorimap/couple/application/dto/response/CoupleEditResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/application/dto/response/CoupleEditResponse.java
@@ -1,0 +1,18 @@
+package com.musseukpeople.woorimap.couple.application.dto.response;
+
+import java.time.LocalDate;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CoupleEditResponse {
+
+    private LocalDate startDate;
+
+    public CoupleEditResponse(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -58,8 +58,8 @@ public class Couple extends BaseEntity {
 
     public void changStartDate(LocalDate modifyDate) {
         checkArgument(modifyDate.isBefore(LocalDate.now().plusDays(1)),
-            "현재 이후 날짜로 커플을 생성할 수 없습니다.");
-        
+            "현재 이후 날짜로 커플을 수정할 수 없습니다.");
+
         this.startDate = modifyDate;
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -55,4 +55,8 @@ public class Couple extends BaseEntity {
     public Member getOpponentMember(Long id) {
         return this.coupleMembers.getOpponentMember(id);
     }
+
+    public void changStartDate(LocalDate modifyDate) {
+        this.startDate = modifyDate;
+    }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -57,6 +57,9 @@ public class Couple extends BaseEntity {
     }
 
     public void changStartDate(LocalDate modifyDate) {
+        checkArgument(modifyDate.isBefore(LocalDate.now().plusDays(1)),
+            "현재 이후 날짜로 커플을 생성할 수 없습니다.");
+        
         this.startDate = modifyDate;
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/presentation/CoupleController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,8 @@ import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.couple.application.CoupleFacade;
 import com.musseukpeople.woorimap.couple.application.dto.request.CreateCoupleRequest;
+import com.musseukpeople.woorimap.couple.application.dto.request.EditCoupleRequest;
+import com.musseukpeople.woorimap.couple.application.dto.response.CoupleEditResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.CoupleResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 
@@ -57,7 +60,18 @@ public class CoupleController {
         CoupleResponse coupleResponse = coupleFacade.getCouple(member);
         return ResponseEntity.ok(new ApiResponse<>(coupleResponse));
     }
-    
+
+    @Operation(summary = "커플 수정", description = "커플 수정 API입니다.")
+    @OnlyCouple
+    @PutMapping
+    public ResponseEntity<ApiResponse<CoupleEditResponse>> editCouple(
+        @Valid @RequestBody EditCoupleRequest editCoupleRequest,
+        @Login LoginMember member) {
+        CoupleEditResponse coupleEditResponse = coupleFacade.modifyCouple(member.getCoupleId(),
+            editCoupleRequest.getEditDate());
+        return ResponseEntity.ok(new ApiResponse<>(coupleEditResponse));
+    }
+
     @Operation(summary = "커플 해제", description = "커플 해제 API입니다.")
     @OnlyCouple
     @DeleteMapping

--- a/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/application/CoupleServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.musseukpeople.woorimap.couple.application.dto.response.CoupleEditResponse;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.member.domain.Member;
@@ -23,7 +24,7 @@ class CoupleServiceTest extends IntegrationTest {
 
     private static final TCoupleBuilder coupleBuilder = new TCoupleBuilder();
     private static final Long COUPLE_ID = 1L;
-    private static final LocalDate COUPLE_START_DATE = LocalDate.of(2022, 1, 1);
+    private static final LocalDate COUPLE_START_DATE = LocalDate.of(2022, 8, 4);
 
     @Autowired
     private CoupleService coupleService;
@@ -68,6 +69,25 @@ class CoupleServiceTest extends IntegrationTest {
             //then
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("커플 인원이 2명이 아닙니다");
+    }
+
+    @DisplayName("커플 수정 성공")
+    @Test
+    void modify_success() {
+        //given
+        Couple testCouple = coupleBuilder.id(COUPLE_ID).startDate(COUPLE_START_DATE).build();
+        Couple couple = coupleRepository.save(testCouple);
+        LocalDate modifyDate = LocalDate.of(2022, 6, 28);
+        Long coupleId = couple.getId();
+
+        //when
+        CoupleEditResponse coupleEditResponse = coupleService.modifyCouple(coupleId, modifyDate);
+        Couple findCouple = coupleRepository.findById(coupleId).get();
+
+        //then
+        assertThat(coupleEditResponse.getStartDate()).isEqualTo(modifyDate);
+        assertThat(findCouple.getStartDate()).isNotEqualTo(COUPLE_START_DATE);
+        assertThat(findCouple.getStartDate()).isEqualTo(modifyDate);
     }
 
     @DisplayName("커플 조회 성공")

--- a/src/test/java/com/musseukpeople/woorimap/couple/presentation/CoupleControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/presentation/CoupleControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -19,6 +20,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.couple.application.dto.request.CreateCoupleRequest;
+import com.musseukpeople.woorimap.couple.application.dto.request.EditCoupleRequest;
+import com.musseukpeople.woorimap.couple.application.dto.response.CoupleEditResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.CoupleResponse;
 import com.musseukpeople.woorimap.couple.application.dto.response.InviteCodeResponse;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
@@ -125,6 +128,29 @@ class CoupleControllerTest extends AcceptanceTest {
             //then
             .andExpect(status().isForbidden())
             .andDo(print());
+    }
+
+    @DisplayName("커플 수정 API 성공")
+    @Test
+    void modify_success() throws Exception {
+        //given
+        String coupleToken = 커플_맺기_토큰(accessToken);
+        LocalDate modifyDate = LocalDate.of(1996, 6, 28);
+        EditCoupleRequest editCoupleRequest = new EditCoupleRequest(modifyDate);
+
+        //when
+        MockHttpServletResponse response = mockMvc.perform(put("/api/couples")
+                .header(HttpHeaders.AUTHORIZATION, coupleToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(editCoupleRequest)))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andReturn().getResponse();
+
+        CoupleEditResponse editResponse = getResponseObject(response, CoupleEditResponse.class);
+
+        //then
+        assertThat(editResponse.getStartDate()).isEqualTo(modifyDate);
     }
 
     @DisplayName("커플 초대 코드 생성 API 성공")


### PR DESCRIPTION
## 요약
커플 수정 API 구현
<br><br>

## 작업 내용
- 커플 수정 Request, Response 생성

- 커플 수정 서비스 기능 구현

- 커플 도메인에 사귄날 수정 메소드 추가

- 커플 수정 API 구현

- 커플 수정 테스트 코드 작성
  - Update 로그 확인
<br><br>

## 참고 사항

<br><br>
