### PR TITLE
[WOOR-168] refactor: 회원 프로필 조회시 자신의 정보만 변경하도록 변경

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/MemberService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
-import com.musseukpeople.woorimap.couple.exception.NotFoundCoupleException;
 import com.musseukpeople.woorimap.member.application.dto.request.EditProfileRequest;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
@@ -55,12 +54,7 @@ public class MemberService {
 
     public MemberResponse getMemberResponseById(Long id) {
         Member member = getMemberWithCoupleById(id);
-
-        if (member.isCouple()) {
-            Member opponentMember = getOpponentMember(member);
-            return MemberResponse.createCoupleMemberResponse(member, opponentMember);
-        }
-        return MemberResponse.createSoloMemberResponse(member);
+        return MemberResponse.from(member);
     }
 
     public Member getMemberById(Long id) {
@@ -92,12 +86,5 @@ public class MemberService {
         if (memberRepository.existsByEmailValue(email)) {
             throw new DuplicateEmailException(email, ErrorCode.DUPLICATE_EMAIL);
         }
-    }
-
-    private Member getOpponentMember(Member member) {
-        Long id = member.getId();
-        Long coupleId = member.getCouple().getId();
-        return memberRepository.findOpponentMember(id, coupleId)
-            .orElseThrow(() -> new NotFoundCoupleException(ErrorCode.NOT_FOUND_MEMBER, coupleId));
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/member/application/dto/response/MemberResponse.java
@@ -1,7 +1,5 @@
 package com.musseukpeople.woorimap.member.application.dto.response;
 
-import java.time.LocalDate;
-
 import com.musseukpeople.woorimap.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,40 +17,19 @@ public class MemberResponse {
     @Schema(description = "닉네임")
     private String nickName;
 
-    @Schema(description = "커플 상대방 닉네임", nullable = true)
-    private String coupleNickName;
-
-    @Schema(description = "커플 시작 날짜", nullable = true)
-    private LocalDate coupleStartingDate;
-
     @Schema(description = "커플 유무")
     private boolean isCouple;
 
-    public MemberResponse(String imageUrl, String nickName, String coupleNickName, LocalDate coupleStartingDate,
-                          boolean isCouple) {
+    public MemberResponse(String imageUrl, String nickName, boolean isCouple) {
         this.imageUrl = imageUrl;
         this.nickName = nickName;
-        this.coupleNickName = coupleNickName;
-        this.coupleStartingDate = coupleStartingDate;
         this.isCouple = isCouple;
     }
 
-    public static MemberResponse createSoloMemberResponse(Member member) {
+    public static MemberResponse from(Member member) {
         return new MemberResponse(
             member.getImageUrl(),
             member.getNickName().getValue(),
-            null,
-            null,
-            member.isCouple()
-        );
-    }
-
-    public static MemberResponse createCoupleMemberResponse(Member member, Member opponentMember) {
-        return new MemberResponse(
-            member.getImageUrl(),
-            member.getNickName().getValue(),
-            opponentMember.getNickName().getValue(),
-            member.getCouple().getStartDate(),
             member.isCouple()
         );
     }

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -17,8 +17,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.EditProfileRequest;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
-import com.musseukpeople.woorimap.member.application.dto.response.ProfileResponse;
 import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
+import com.musseukpeople.woorimap.member.application.dto.response.ProfileResponse;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
 
 class MemberAcceptanceTest extends AcceptanceTest {
@@ -109,28 +109,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
         MemberResponse memberResponse = getResponseObject(response, MemberResponse.class);
         assertAll(
             () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(memberResponse.getNickName()).isEqualTo(nickName),
             () -> assertThat(memberResponse.isCouple()).isFalse()
-        );
-    }
-
-    @DisplayName("커플 회원 정보 조회 성공")
-    @Test
-    void showMember_couple_success() throws Exception {
-        // given
-        String email = "test@gmail.com";
-        String password = "!Hwan1234";
-        String nickName = "hwan";
-        String accessToken = 회원가입_토큰(new SignupRequest(email, password, nickName));
-        String coupleAccessToken = 커플_맺기_토큰(accessToken);
-
-        // when
-        MockHttpServletResponse response = 회원_정보_조회(coupleAccessToken);
-
-        // then
-        MemberResponse memberResponse = getResponseObject(response, MemberResponse.class);
-        assertAll(
-            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(memberResponse.getCoupleNickName()).isNotNull()
         );
     }
 

--- a/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/acceptance/MemberAcceptanceTest.java
@@ -93,9 +93,9 @@ class MemberAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("솔로 회원 정보 조회 성공")
+    @DisplayName("회원 정보 조회 성공")
     @Test
-    void showMember_solo_success() throws Exception {
+    void showMember_success() throws Exception {
         // given
         String email = "test@gmail.com";
         String password = "!Hwan1234";
@@ -112,13 +112,6 @@ class MemberAcceptanceTest extends AcceptanceTest {
             () -> assertThat(memberResponse.getNickName()).isEqualTo(nickName),
             () -> assertThat(memberResponse.isCouple()).isFalse()
         );
-    }
-
-    private MockHttpServletResponse 회원_정보_조회(String accessToken) throws Exception {
-        return mockMvc.perform(get("/api/members")
-                .header(HttpHeaders.AUTHORIZATION, accessToken))
-            .andDo(print())
-            .andReturn().getResponse();
     }
 
     @DisplayName("URL이 아닌 아님으로 인한 프로필 수정 실패")
@@ -169,5 +162,12 @@ class MemberAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value()),
             () -> assertThat(errorResponse.getErrors().get(0).getReason()).isEqualTo("올바른 이미지 URL이 아닙니다.")
         );
+    }
+
+    private MockHttpServletResponse 회원_정보_조회(String accessToken) throws Exception {
+        return mockMvc.perform(get("/api/members")
+                .header(HttpHeaders.AUTHORIZATION, accessToken))
+            .andDo(print())
+            .andReturn().getResponse();
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/member/application/MemberServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/member/application/MemberServiceTest.java
@@ -3,27 +3,22 @@ package com.musseukpeople.woorimap.member.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
-import com.musseukpeople.woorimap.member.application.dto.request.EditProfileRequest;
-import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.member.application.dto.request.EditProfileRequest;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
-import com.musseukpeople.woorimap.member.application.dto.response.ProfileResponse;
 import com.musseukpeople.woorimap.member.application.dto.response.MemberResponse;
+import com.musseukpeople.woorimap.member.application.dto.response.ProfileResponse;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
 import com.musseukpeople.woorimap.member.exception.DuplicateEmailException;
 import com.musseukpeople.woorimap.member.exception.LoginFailedException;
 import com.musseukpeople.woorimap.member.exception.NotFoundMemberException;
-import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
 import com.musseukpeople.woorimap.util.IntegrationTest;
-import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
 import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
 
 class MemberServiceTest extends IntegrationTest {
@@ -91,7 +86,7 @@ class MemberServiceTest extends IntegrationTest {
             .hasMessageContaining("이메일 또는 비밀번호가 일치하지 않습니다.");
     }
 
-    @DisplayName("회원 정보 조회 성공 - 솔로")
+    @DisplayName("회원 정보 조회 성공")
     @Test
     void getMemberResponse_solo_success() {
         // given
@@ -103,29 +98,8 @@ class MemberServiceTest extends IntegrationTest {
 
         // then
         assertAll(
-            () -> assertThat(memberResponse.getCoupleNickName()).isNull(),
-            () -> assertThat(memberResponse.getCoupleStartingDate()).isNull()
-        );
-    }
-
-    @DisplayName("회원 정보 조회 성공 - 커플")
-    @Test
-    void getMemberResponse_couple_success() {
-        // given
-        Couple couple = new TCoupleBuilder().build();
-        coupleRepository.save(couple);
-        Member member = new TMemberBuilder().email("test@gmail.com").couple(couple).build();
-        Member opponentMember = new TMemberBuilder().email("oppent@gmail.com").couple(couple).build();
-        Long id = memberRepository.save(member).getId();
-        memberRepository.save(opponentMember);
-
-        // when
-        MemberResponse memberResponse = memberService.getMemberResponseById(id);
-
-        // then
-        assertAll(
-            () -> assertThat(memberResponse.getCoupleNickName()).isEqualTo(opponentMember.getNickName().getValue()),
-            () -> assertThat(memberResponse.getCoupleStartingDate()).isEqualTo(LocalDate.now())
+            () -> assertThat(memberResponse.getNickName()).isNotNull(),
+            () -> assertThat(memberResponse.getImageUrl()).isNotNull()
         );
     }
 


### PR DESCRIPTION
## 요약
- 회원 프로필 조회 시 자신의 정보만 반환하도록 변경 

<br><br>

## 작업 내용
- 회원 프로필 조회시 회원의 정보만 반환하도록 하였습니다. 
- 굳이 상대방의 정보까지 주는 것은 커플의 책임이라고 생각했습니다.

<br><br>

## 참고 사항
- 멘토님의 말씀
<img width="450" alt="스크린샷 2022-08-04 오후 4 42 56" src="https://user-images.githubusercontent.com/65746780/182792170-2a5a5421-919d-4b82-9e58-e85c4d705c1d.png">

<br><br>
