### PR TITLE
[WOOR-179] feat: 태그 조회 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisCachingConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisCachingConfig.java
@@ -1,0 +1,60 @@
+package com.musseukpeople.woorimap.common.config.redis;
+
+import java.time.Duration;
+import java.util.ArrayList;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@EnableCaching
+@Configuration
+@Profile("!test")
+@RequiredArgsConstructor
+public class RedisCachingConfig {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final ObjectMapper objectMapper;
+
+    @Bean(name = "cacheManager")
+    public CacheManager redisCacheManager() {
+        CollectionType collectionType = objectMapper.getTypeFactory()
+            .constructCollectionType(ArrayList.class, TagResponse.class);
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+            .defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new Jackson2JsonRedisSerializer<>(
+                        collectionType
+                    )
+                )
+            )
+            .entryTtl(Duration.ofMinutes(30));
+
+        return RedisCacheManager
+            .RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build();
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/CreatePostRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/CreatePostRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.post.domain.Post;
 import com.musseukpeople.woorimap.post.domain.vo.Location;
-import com.musseukpeople.woorimap.tag.application.dto.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
-import com.musseukpeople.woorimap.tag.application.dto.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 import com.musseukpeople.woorimap.tag.domain.TagRepository;
 import com.musseukpeople.woorimap.tag.domain.Tags;

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 import com.musseukpeople.woorimap.tag.domain.TagRepository;
 import com.musseukpeople.woorimap.tag.domain.Tags;
@@ -31,6 +32,12 @@ public class TagService {
         tagRepository.saveAll(newTags.getList());
 
         return existTags.addAll(newTags);
+    }
+
+    public List<TagResponse> getCoupleTags(Long id) {
+        return tagRepository.findAllByCoupleId(id).stream()
+            .map(tag -> new TagResponse(tag.getName(), tag.getColor()))
+            .collect(toList());
     }
 
     private Tags toTags(Couple couple, List<TagRequest> tagRequestList) {

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/dto/request/TagRequest.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/dto/request/TagRequest.java
@@ -1,4 +1,4 @@
-package com.musseukpeople.woorimap.tag.application.dto;
+package com.musseukpeople.woorimap.tag.application.dto.request;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
@@ -1,0 +1,18 @@
+package com.musseukpeople.woorimap.tag.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TagResponse {
+
+    private String name;
+    private String color;
+
+    public TagResponse(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.tag.application.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TagResponse {
 
+    @Schema(description = "태그 이름")
     private String name;
+
+    @Schema(description = "태그 색깔")
     private String color;
 
     public TagResponse(String name, String color) {

--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
@@ -1,8 +1,15 @@
 package com.musseukpeople.woorimap.tag.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.musseukpeople.woorimap.tag.infrastructure.QueryTagRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long>, QueryTagRepository {
+
+    @Query("SELECT t FROM Tag t WHERE t.couple.id = :coupleId")
+    List<Tag> findAllByCoupleId(@Param("coupleId") Long coupleId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
@@ -12,8 +12,6 @@ import com.musseukpeople.woorimap.tag.infrastructure.QueryTagRepository;
 
 public interface TagRepository extends Repository<Tag, Long>, QueryTagRepository {
 
-    Tag save(Tag tag);
-
     @CacheEvict(
         key = "#p0.iterator().next().couple.id",
         value = "coupleTags",

--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/TagRepository.java
@@ -2,14 +2,27 @@ package com.musseukpeople.woorimap.tag.domain;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
+import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.tag.infrastructure.QueryTagRepository;
 
-public interface TagRepository extends JpaRepository<Tag, Long>, QueryTagRepository {
+public interface TagRepository extends Repository<Tag, Long>, QueryTagRepository {
+
+    Tag save(Tag tag);
+
+    @CacheEvict(
+        key = "#p0.iterator().next().couple.id",
+        value = "coupleTags",
+        condition = "#p0 != null && #p0.iterator().hasNext()"
+    )
+    void saveAll(Iterable<Tag> tags);
 
     @Query("SELECT t FROM Tag t WHERE t.couple.id = :coupleId")
     List<Tag> findAllByCoupleId(@Param("coupleId") Long coupleId);
+
+    List<Tag> findExistTagByCouple(Couple couple, List<String> tagNames);
 }

--- a/src/main/java/com/musseukpeople/woorimap/tag/infrastructure/QueryTagRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/infrastructure/QueryTagRepository.java
@@ -6,5 +6,5 @@ import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 
 public interface QueryTagRepository {
-    List<Tag> findExistTagByCoupleId(Couple couple, List<String> tagNameList);
+    List<Tag> findExistTagByCouple(Couple couple, List<String> tagNames);
 }

--- a/src/main/java/com/musseukpeople/woorimap/tag/infrastructure/QueryTagRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/infrastructure/QueryTagRepositoryImpl.java
@@ -19,7 +19,7 @@ public class QueryTagRepositoryImpl implements QueryTagRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Tag> findExistTagByCoupleId(Couple couple, List<String> tagNames) {
+    public List<Tag> findExistTagByCouple(Couple couple, List<String> tagNames) {
         return jpaQueryFactory.selectFrom(tag)
             .where(
                 tag.couple.eq(couple),

--- a/src/main/java/com/musseukpeople/woorimap/tag/presentation/TagController.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/presentation/TagController.java
@@ -1,0 +1,32 @@
+package com.musseukpeople.woorimap.tag.presentation;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.musseukpeople.woorimap.auth.aop.OnlyCouple;
+import com.musseukpeople.woorimap.auth.domain.login.Login;
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.common.model.ApiResponse;
+import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "태그", description = "태그 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/couples/tags")
+public class TagController {
+
+    @Operation(summary = "태그 전체 조회", description = "태그 전체 조회 API입니다.")
+    @OnlyCouple
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TagResponse>>> showAll(@Login LoginMember loginMember) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/tag/presentation/TagController.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/presentation/TagController.java
@@ -11,6 +11,7 @@ import com.musseukpeople.woorimap.auth.aop.OnlyCouple;
 import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
+import com.musseukpeople.woorimap.tag.application.TagService;
 import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,10 +24,13 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/couples/tags")
 public class TagController {
 
+    private final TagService tagService;
+
     @Operation(summary = "태그 전체 조회", description = "태그 전체 조회 API입니다.")
     @OnlyCouple
     @GetMapping
     public ResponseEntity<ApiResponse<List<TagResponse>>> showAll(@Login LoginMember loginMember) {
-        return ResponseEntity.ok().build();
+        List<TagResponse> tagResponses = tagService.getCoupleTags(loginMember.getCoupleId());
+        return ResponseEntity.ok(new ApiResponse<>(tagResponses));
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/post/application/PostFacadeTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/application/PostFacadeTest.java
@@ -17,7 +17,7 @@ import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
 import com.musseukpeople.woorimap.post.application.dto.CreatePostRequest;
-import com.musseukpeople.woorimap.tag.application.dto.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.tag.exception.DuplicateTagException;
 import com.musseukpeople.woorimap.util.IntegrationTest;
 import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;

--- a/src/test/java/com/musseukpeople/woorimap/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/presentation/PostControllerTest.java
@@ -2,8 +2,6 @@ package com.musseukpeople.woorimap.post.presentation;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -14,13 +12,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.post.application.dto.CreatePostRequest;
-import com.musseukpeople.woorimap.tag.application.dto.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
 
 class PostControllerTest extends AcceptanceTest {
@@ -52,12 +49,7 @@ class PostControllerTest extends AcceptanceTest {
             .build();
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/api/couples/posts")
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, coupleAccessToken)
-                .content(objectMapper.writeValueAsString(request)))
-            .andDo(print())
-            .andReturn().getResponse();
+        MockHttpServletResponse response = 게시글_작성(coupleAccessToken, request);
 
         // then
         assertAll(

--- a/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
@@ -1,6 +1,7 @@
 package com.musseukpeople.woorimap.tag.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,6 +17,7 @@ import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
 import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 import com.musseukpeople.woorimap.tag.domain.TagRepository;
 import com.musseukpeople.woorimap.tag.domain.Tags;
@@ -68,6 +70,23 @@ class TagServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> tagService.findOrCreateTags(couple, tagRequests))
             .isInstanceOf(DuplicateTagException.class)
             .hasMessage("태그가 중복됩니다.");
+    }
+
+    @DisplayName("태그 조회 성공")
+    @Test
+    void getCoupleTags() {
+        // given
+        tagRepository.saveAll(List.of(new Tag("서울", "#FFFFFF", couple), new Tag("맛집", "#FFFFFF", couple)));
+
+        // when
+        List<TagResponse> tags = tagService.getCoupleTags(couple.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(tags).hasSize(2),
+            () -> assertThat(tags).extracting("name").containsExactly("서울", "맛집")
+        );
+
     }
 
     private Couple createCouple() {

--- a/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
@@ -15,7 +15,7 @@ import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
-import com.musseukpeople.woorimap.tag.application.dto.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.tag.domain.Tag;
 import com.musseukpeople.woorimap.tag.domain.TagRepository;
 import com.musseukpeople.woorimap.tag.domain.Tags;

--- a/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/tag/application/TagServiceTest.java
@@ -50,7 +50,7 @@ class TagServiceTest extends IntegrationTest {
     @Test
     void createTag_success() {
         // given
-        tagRepository.save(new Tag("서울", "#FFFFFF", couple));
+        tagRepository.saveAll(List.of(new Tag("서울", "#FFFFFF", couple)));
         List<TagRequest> tagRequests = List.of(new TagRequest("서울", "#FFFFFF"), new TagRequest("맛집", "#AAAAAA"));
 
         // when

--- a/src/test/java/com/musseukpeople/woorimap/tag/presentation/TagControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/tag/presentation/TagControllerTest.java
@@ -1,0 +1,65 @@
+package com.musseukpeople.woorimap.tag.presentation;
+
+import static java.util.stream.Collectors.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.post.application.dto.CreatePostRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
+import com.musseukpeople.woorimap.tag.application.dto.response.TagResponse;
+import com.musseukpeople.woorimap.util.AcceptanceTest;
+
+class TagControllerTest extends AcceptanceTest {
+
+    @DisplayName("태그 조회 성공")
+    @Test
+    void showAll() throws Exception {
+        // given
+        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Hwan1234", "Hwan"));
+        accessToken = 커플_맺기_토큰(accessToken);
+        게시글_작성(accessToken, createPostRequestWithTag("서울", "부산", "맛집"));
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(get("/api/couples/tags")
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andReturn().getResponse();
+
+        // then
+        List<TagResponse> tagResponses = getResponseList(response, TagResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(tagResponses).hasSize(3)
+        );
+    }
+
+    private CreatePostRequest createPostRequestWithTag(String... names) {
+        List<TagRequest> tagRequests = Arrays.stream(names)
+            .map(name -> new TagRequest(name, "#FFFFFF"))
+            .collect(toList());
+
+        return CreatePostRequest.builder()
+            .title("첫 이야기")
+            .content("<h1>첫 이야기.... </h1>")
+            .imageUrls(List.of("imageUrl1", "imageUrl2"))
+            .tags(tagRequests)
+            .datingDate(LocalDate.now())
+            .latitude(new BigDecimal("12.12312321"))
+            .longitude(new BigDecimal("122.3123121"))
+            .build();
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,6 +112,13 @@ public abstract class AcceptanceTest {
     protected <T> T getResponseObject(MockHttpServletResponse response, Class<T> type) throws IOException {
         JavaType javaType = objectMapper.getTypeFactory().constructParametricType(ApiResponse.class, type);
         ApiResponse<T> result = objectMapper.readValue(response.getContentAsString(), javaType);
+        return result.getData();
+    }
+
+    protected <T> List<T> getResponseList(MockHttpServletResponse response, Class<T> type) throws IOException {
+        JavaType insideType = objectMapper.getTypeFactory().constructParametricType(List.class, type);
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(ApiResponse.class, insideType);
+        ApiResponse<List<T>> result = objectMapper.readValue(response.getContentAsString(), javaType);
         return result.getData();
     }
 

--- a/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/AcceptanceTest.java
@@ -24,6 +24,7 @@ import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.couple.application.dto.request.CreateCoupleRequest;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.post.application.dto.CreatePostRequest;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -92,6 +93,15 @@ public abstract class AcceptanceTest {
     protected String 커플_맺기_토큰(String accessToken) throws Exception {
         MockHttpServletResponse response = 커플_맺기(accessToken);
         return "Bearer" + getResponseObject(response, LoginResponse.class).getAccessToken();
+    }
+
+    protected MockHttpServletResponse 게시글_작성(String token, CreatePostRequest request) throws Exception {
+        return mockMvc.perform(post("/api/couples/posts")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andReturn().getResponse();
     }
 
     protected ErrorResponse getErrorResponse(MockHttpServletResponse response) throws IOException {


### PR DESCRIPTION
## 요약
- 태그 조회 API 구현
<br><br>

## 작업 내용
- 커플 id 기준 태그 조회 기능 구현 (85e2722e36ed2310f247716e55fe02a4dc2e96c7)
- Redis 캐싱 구현 ( 589bd59ec9caea1e992c08a63474c4a687243be4) 
  - Look Aside Cache 전략을 사용 했습니다. (캐시 저장소에 데이터가 있으면, 캐시에서 가져오고, 없으면 메인 DB에서 값을 가져오는 대표적인 캐시 전략 ) 
  - 둘 다 서비스 레이어에서 캐싱을 해주고 싶었지만 현재 로직이 요청값의 태그 이름으로 찾고 없으면 저장하기 때문에 메서드로 분리하여 적용해보려고 했지만 캐시 어노테이션도 결국 AOP 기반이기 때문에 내부 클래스에선 적용할 수 없어서 Repository로 해당 책임을 바꾸었습니다. 
  - AspectJ 모드로 하면 내부 클래스에서도 AOP를 적용할 수 있지만 jvm옵션에 jar파일을 넣어줘야 해서 일단 패스했습니다. 
  - self invocation 등 방법도 있지만 마음에 들지 않아 일단 Repository에서 Evit을 할 수 있도록 했습니다. 

<br><br>

## 참고 사항
- [Redis 캐시 설정](https://github.com/2021-pick-git/2021-pick-git.github.io/blob/main/_posts/2021-10-19-spring-cache-with-redis.md)
- [Spring @Transactional, @Caching 그리고 AspectJ — 2편 : AspectJ](https://medium.com/chequer/spring-transactional-caching-%EA%B7%B8%EB%A6%AC%EA%B3%A0-aspectj-2%ED%8E%B8-aspectj-689319db329f)
- [Self Invocation은 왜 발생할까?](https://gmoon92.github.io/spring/aop/2019/04/01/spring-aop-mechanism-with-self-invocation.html)
- locust로 성능테스트를 해보았는 데 잘 나온건지는 모르겠네요 ㅎㅎ 
  - 조건 : User 1000명 , 태그 1000개 
  - 캐싱 적용 전 (DB 접속) 
<img width="1135" alt="스크린샷 2022-08-07 오후 5 41 31" src="https://user-images.githubusercontent.com/65746780/183282738-94b0077b-3528-41b5-916c-0236a51c2bc5.png">   
   - 캐싱 적용 후 (Redis 캐싱)
<img width="1077" alt="스크린샷 2022-08-07 오후 5 41 19" src="https://user-images.githubusercontent.com/65746780/183282734-e7700f6a-d8a5-4f21-a5bc-7dcfd3b3c370.png">

- 전체적인 응답속도는 빨라지긴 했지만 RPS가 같아서 뭐가 뭔지 잘 모르겠네요 ㅎㅎ
<br><br>
