### PR TITLE
[WOOR-61] feat: 게시글 다건 조회 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.post.application;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,7 +10,9 @@ import com.musseukpeople.woorimap.couple.application.CoupleService;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
 import com.musseukpeople.woorimap.post.application.dto.response.PostResponse;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.domain.Post;
 import com.musseukpeople.woorimap.post.exception.PostNotBelongToCoupleException;
 import com.musseukpeople.woorimap.tag.application.TagService;
@@ -30,6 +34,10 @@ public class PostFacade {
         Couple couple = coupleService.getCoupleById(coupleId);
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
         return postService.createPost(couple, tags.getList(), createPostRequest);
+    }
+
+    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
+        return postService.searchPosts(postFilterCondition, coupleId);
     }
 
     @Transactional

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
@@ -9,6 +9,8 @@ import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.domain.Post;
 import com.musseukpeople.woorimap.post.domain.PostRepository;
 import com.musseukpeople.woorimap.post.exception.NotFoundPostException;
@@ -27,6 +29,11 @@ public class PostService {
     public Long createPost(Couple couple, List<Tag> tags, CreatePostRequest createPostRequest) {
         Post post = createPostRequest.toPost(couple, tags);
         return postRepository.save(post).getId();
+    }
+
+    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
+        List<Post> posts = postRepository.findPostsByFilterCondition(postFilterCondition, coupleId);
+        return PostSearchResponse.from(posts);
     }
 
     @Transactional

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/request/PostFilterCondition.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/request/PostFilterCondition.java
@@ -2,6 +2,7 @@ package com.musseukpeople.woorimap.post.application.dto.request;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +11,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostFilterCondition {
 
+    @Schema(description = "태그 아이디")
     private List<Long> tagIds;
+
+    @Schema(description = "제목")
     private String title;
+
+    @Schema(description = "마지막 게시글 아이디")
     private Long lastPostId;
+
+    @Schema(description = "사이즈")
     private int paginationSize = 20;
 
     public PostFilterCondition(List<Long> tagIds, String title, Long lastPostId) {

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/request/PostFilterCondition.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/request/PostFilterCondition.java
@@ -1,0 +1,23 @@
+package com.musseukpeople.woorimap.post.application.dto.request;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostFilterCondition {
+
+    private List<Long> tagIds;
+    private String title;
+    private Long lastPostId;
+    private int paginationSize = 20;
+
+    public PostFilterCondition(List<Long> tagIds, String title, Long lastPostId) {
+        this.tagIds = tagIds;
+        this.title = title;
+        this.lastPostId = lastPostId;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
@@ -2,11 +2,8 @@ package com.musseukpeople.woorimap.post.application.dto.response;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import com.musseukpeople.woorimap.post.domain.Post;
-
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,32 +13,32 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostSearchResponse {
 
+    @Schema(description = "게시글 아이디")
     private Long postId;
-    private String postThumbnailPath;
+
+    @Schema(description = "썸네일 사진")
+    private String imageUrl;
+
+    @Schema(description = "제목")
     private String title;
+
+    @Schema(description = "작성일")
     private LocalDateTime createDateTime;
+
+    @Schema(description = "위도")
     private BigDecimal latitude;
+
+    @Schema(description = "경도")
     private BigDecimal longitude;
 
     @Builder
-    private PostSearchResponse(Long postId, String postThumbnailPath, String title, LocalDateTime createDateTime,
-                               BigDecimal latitude, BigDecimal longitude) {
+    public PostSearchResponse(Long postId, String imageUrl, String title, LocalDateTime createDateTime,
+                              BigDecimal latitude, BigDecimal longitude) {
         this.postId = postId;
-        this.postThumbnailPath = postThumbnailPath;
+        this.imageUrl = imageUrl;
         this.title = title;
         this.createDateTime = createDateTime;
         this.latitude = latitude;
         this.longitude = longitude;
-    }
-
-    public static List<PostSearchResponse> from(List<Post> posts) {
-        return posts.stream().map(post -> new PostSearchResponse(
-            post.getId(),
-            post.getTitle(),
-            post.getThumbnailUrl(),
-            post.getCreatedDateTime(),
-            post.getLocation().getLatitude(),
-            post.getLocation().getLongitude()
-        )).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
@@ -2,6 +2,10 @@ package com.musseukpeople.woorimap.post.application.dto.response;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.musseukpeople.woorimap.post.domain.Post;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -40,5 +44,16 @@ public class PostSearchResponse {
         this.createDateTime = createDateTime;
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public static List<PostSearchResponse> from(List<Post> posts) {
+        return posts.stream().map(post -> new PostSearchResponse(
+            post.getId(),
+            post.getThumbnailUrl(),
+            post.getTitle(),
+            post.getCreatedDateTime(),
+            post.getLocation().getLatitude(),
+            post.getLocation().getLongitude()
+        )).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/dto/response/PostSearchResponse.java
@@ -1,0 +1,47 @@
+package com.musseukpeople.woorimap.post.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.musseukpeople.woorimap.post.domain.Post;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostSearchResponse {
+
+    private Long postId;
+    private String postThumbnailPath;
+    private String title;
+    private LocalDateTime createDateTime;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    @Builder
+    private PostSearchResponse(Long postId, String postThumbnailPath, String title, LocalDateTime createDateTime,
+                               BigDecimal latitude, BigDecimal longitude) {
+        this.postId = postId;
+        this.postThumbnailPath = postThumbnailPath;
+        this.title = title;
+        this.createDateTime = createDateTime;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static List<PostSearchResponse> from(List<Post> posts) {
+        return posts.stream().map(post -> new PostSearchResponse(
+            post.getId(),
+            post.getTitle(),
+            post.getThumbnailUrl(),
+            post.getCreatedDateTime(),
+            post.getLocation().getLatitude(),
+            post.getLocation().getLongitude()
+        )).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/post/domain/PostRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/domain/PostRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+import com.musseukpeople.woorimap.post.infrastructure.PostQueryRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
 
     @Query("SELECT p FROM Post p "
         + "JOIN FETCH p.postImages.postImages "

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
@@ -1,0 +1,11 @@
+package com.musseukpeople.woorimap.post.infrastructure;
+
+import java.util.List;
+
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.domain.Post;
+
+public interface PostQueryRepository {
+
+    List<Post> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId);
+}

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
@@ -3,9 +3,9 @@ package com.musseukpeople.woorimap.post.infrastructure;
 import java.util.List;
 
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
-import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
+import com.musseukpeople.woorimap.post.domain.Post;
 
 public interface PostQueryRepository {
 
-    List<PostSearchResponse> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId);
+    List<Post> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepository.java
@@ -3,9 +3,9 @@ package com.musseukpeople.woorimap.post.infrastructure;
 import java.util.List;
 
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
-import com.musseukpeople.woorimap.post.domain.Post;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 
 public interface PostQueryRepository {
 
-    List<Post> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId);
+    List<PostSearchResponse> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId);
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.musseukpeople.woorimap.post.infrastructure;
+
+import static com.musseukpeople.woorimap.post.domain.QPost.*;
+import static com.musseukpeople.woorimap.post.domain.image.QPostImage.*;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.domain.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PostQueryRepositoryImpl implements PostQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId) {
+
+        return jpaQueryFactory.select(post)
+            .from(post)
+            .innerJoin(post.postImages.postImages, postImage)
+            .fetchJoin()
+            .where(
+                lastPostIdLo(postFilterCondition.getLastPostId()),
+                titleContain(postFilterCondition.getTitle()),
+                tagsIn(postFilterCondition.getTagIds())
+            )
+            .orderBy(post.id.desc())
+            .limit(postFilterCondition.getPaginationSize())
+            .distinct()
+            .fetch();
+    }
+
+    private BooleanExpression lastPostIdLo(Long lastPostId) {
+        return Objects.isNull(lastPostId) ? null : post.id.lt(lastPostId);
+    }
+
+    private BooleanExpression titleContain(String title) {
+        return Objects.isNull(title) ? null : post.title.contains(title);
+    }
+
+    private BooleanExpression tagsIn(List<Long> tagIds) {
+        return Objects.isNull(tagIds) ? null : post.postTags.postTags.any().tag.id.in(tagIds);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
@@ -26,7 +26,6 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
             .from(post)
             .innerJoin(post.postTags.postTags, postTag)
             .innerJoin(postTag.tag, tag)
-            .on(tag.couple.id.eq(coupleId))
             .distinct()
             .where(
                 coupleIdEq(coupleId),

--- a/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
 import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
+import com.musseukpeople.woorimap.post.domain.image.QPostImages;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,16 +24,33 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
     @Override
     public List<PostSearchResponse> findPostsByFilterCondition(PostFilterCondition postFilterCondition, Long coupleId) {
+        // List<PostSearchResponse> responses = jpaQueryFactory.select(
+        //         Projections.constructor(PostSearchResponse.class,
+        //             post.id.as("postId"),
+        //             postImage.imageUrl.as("imageUrl"),
+        //             post.title.as("title"),
+        //             post.createdDateTime.as("createDateTime"),
+        //             post.location.latitude.as("latitude"),
+        //             post.location.longitude.as("longitude")
+        //         )
+        //     )
+        //     .distinct()
+        //     .from(postImage)
+        //     .innerJoin(postImage.post, post)
+        //     .groupBy(post.id)
+        //     .fetch();
+
         return jpaQueryFactory.select(
                 Projections.constructor(PostSearchResponse.class,
                     post.id.as("postId"),
-                    post.title.as("imageUrl"),
+                    QPostImages.postImages1.postImages.any().imageUrl.as("imageUrl"),
                     post.title.as("title"),
                     post.createdDateTime.as("createDateTime"),
                     post.location.latitude.as("latitude"),
                     post.location.longitude.as("longitude")
                 )
             )
+            .distinct()
             .from(postImage)
             .innerJoin(postImage.post, post)
             .innerJoin(post.postTags.postTags, postTag)

--- a/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
@@ -1,6 +1,7 @@
 package com.musseukpeople.woorimap.post.presentation;
 
 import java.net.URI;
+import java.util.List;
 
 import javax.validation.Valid;
 
@@ -22,6 +23,8 @@ import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.post.application.PostFacade;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.application.dto.response.PostResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +47,16 @@ public class PostController {
         Long coupleId = loginMember.getCoupleId();
         Long postId = postFacade.createPost(coupleId, createPostRequest);
         return ResponseEntity.created(createURI(postId)).build();
+    }
+
+    @Operation(summary = "게시글 다건 조회", description = "게시물 다건 조회 및 검색 API입니다.")
+    @OnlyCouple
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PostSearchResponse>>> getPosts(PostFilterCondition postFilterCondition,
+                                                                          @Login LoginMember member) {
+        Long coupleId = member.getCoupleId();
+        List<PostSearchResponse> postSearchResponses = postFacade.searchPosts(postFilterCondition, coupleId);
+        return ResponseEntity.ok(new ApiResponse<>(postSearchResponses));
     }
 
     @Operation(summary = "게시물 단건 조회", description = "게시물 단건 조회 API입니다.")

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/TagService.java
@@ -43,7 +43,7 @@ public class TagService {
     public List<TagResponse> getCoupleTags(Long coupleId) {
         List<Tag> result = tagRepository.findAllByCoupleId(coupleId);
         return result.stream()
-            .map(tag -> new TagResponse(tag.getName(), tag.getColor()))
+            .map(tag -> new TagResponse(tag.getId(), tag.getName(), tag.getColor()))
             .collect(toList());
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/application/dto/response/TagResponse.java
@@ -9,13 +9,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TagResponse {
 
+    @Schema(description = "태그 아이디")
+    private Long id;
+
     @Schema(description = "태그 이름")
     private String name;
 
     @Schema(description = "태그 색깔")
     private String color;
 
-    public TagResponse(String name, String color) {
+    public TagResponse(Long id, String name, String color) {
+        this.id = id;
         this.name = name;
         this.color = color;
     }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        default_batch_fetch_size: 1000
         format_sql: true
 
   flyway:

--- a/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.TestPropertySource;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.domain.Post;
 import com.musseukpeople.woorimap.post.domain.PostRepository;
 import com.musseukpeople.woorimap.post.domain.vo.Location;
@@ -27,7 +27,6 @@ import com.musseukpeople.woorimap.util.RepositoryTest;
 import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
 
 @RepositoryTest
-@TestPropertySource(properties = "spring.jpa.properties.hibernate.default_batch_fetch_size=1000")
 class PostQueryRepositoryTest {
 
     @Autowired
@@ -64,10 +63,11 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTagFilter = new PostFilterCondition(tagIds, null, null);
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
 
         //then
         assertThat(posts).hasSize(1);
+
     }
 
     @DisplayName("게시물에 없는 tag 아이디로 검색 실패")
@@ -78,7 +78,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTagFilter = new PostFilterCondition(notTagIds, null, null);
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
 
         //then
         assertThat(posts).isEmpty();
@@ -94,7 +94,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, title, null);
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
 
         //then
         assertThat(posts).hasSize(1);
@@ -110,7 +110,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, noTitle, null);
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
 
         //then
         assertThat(posts).isEmpty();
@@ -125,7 +125,7 @@ class PostQueryRepositoryTest {
         }
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(
             new PostFilterCondition(null, null, null), coupleId);
 
         //then
@@ -143,8 +143,8 @@ class PostQueryRepositoryTest {
         }
 
         //when
-        List<Post> posts = postRepository.findPostsByFilterCondition(new PostFilterCondition(tagIds, "테스트", 54378537L),
-            coupleId);
+        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(
+            new PostFilterCondition(tagIds, "테스트", 54378537L), coupleId);
 
         //then
         assertThat(posts).hasSize(20);

--- a/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
-import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.domain.Post;
 import com.musseukpeople.woorimap.post.domain.PostRepository;
 import com.musseukpeople.woorimap.post.domain.vo.Location;
@@ -63,7 +62,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTagFilter = new PostFilterCondition(tagIds, null, null);
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
 
         //then
         assertThat(posts).hasSize(1);
@@ -78,7 +77,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTagFilter = new PostFilterCondition(notTagIds, null, null);
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
 
         //then
         assertThat(posts).isEmpty();
@@ -94,7 +93,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, title, null);
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
 
         //then
         assertThat(posts).hasSize(1);
@@ -110,7 +109,7 @@ class PostQueryRepositoryTest {
         PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, noTitle, null);
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
 
         //then
         assertThat(posts).isEmpty();
@@ -125,7 +124,7 @@ class PostQueryRepositoryTest {
         }
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(
+        List<Post> posts = postRepository.findPostsByFilterCondition(
             new PostFilterCondition(null, null, null), coupleId);
 
         //then
@@ -143,7 +142,7 @@ class PostQueryRepositoryTest {
         }
 
         //when
-        List<PostSearchResponse> posts = postRepository.findPostsByFilterCondition(
+        List<Post> posts = postRepository.findPostsByFilterCondition(
             new PostFilterCondition(tagIds, "테스트", 54378537L), coupleId);
 
         //then
@@ -174,9 +173,7 @@ class PostQueryRepositoryTest {
             "http://wooriemap.aws.com/2.jpg",
             "http://wooriemap.aws.com/3.jpg",
             "http://wooriemap.aws.com/4.jpg",
-            "http://wooriemap.aws.com/5.jpg",
-            "http://wooriemap.aws.com/6.jpg",
-            "http://wooriemap.aws.com/7.jpg");
+            "http://wooriemap.aws.com/5.jpg");
     }
 
     private List<Tag> createTestTags(Couple couple) {

--- a/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/infrastructure/PostQueryRepositoryTest.java
@@ -1,0 +1,194 @@
+package com.musseukpeople.woorimap.post.infrastructure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
+import com.musseukpeople.woorimap.post.domain.Post;
+import com.musseukpeople.woorimap.post.domain.PostRepository;
+import com.musseukpeople.woorimap.post.domain.vo.Location;
+import com.musseukpeople.woorimap.tag.domain.Tag;
+import com.musseukpeople.woorimap.tag.domain.TagRepository;
+import com.musseukpeople.woorimap.util.RepositoryTest;
+import com.musseukpeople.woorimap.util.fixture.TCoupleBuilder;
+
+@RepositoryTest
+@TestPropertySource(properties = "spring.jpa.properties.hibernate.default_batch_fetch_size=1000")
+class PostQueryRepositoryTest {
+
+    @Autowired
+    private CoupleRepository coupleRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    private Couple couple;
+    private Long coupleId;
+    private List<Tag> tags;
+    private List<String> postImages;
+
+    @BeforeEach
+    void setup() {
+        couple = createCouple();
+        tags = createTestTags(couple);
+        postImages = createPostImages();
+
+        coupleId = couple.getId();
+        Post post = createTestPost(couple, tags, postImages);
+
+        postRepository.save(post);
+    }
+
+    @DisplayName("tag 아이디로 검색 성공")
+    @Test
+    void findPostsByFilterCondition() {
+        //given
+        List<Long> tagIds = tags.stream().map(Tag::getId).collect(Collectors.toList());
+        PostFilterCondition onlyTagFilter = new PostFilterCondition(tagIds, null, null);
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+
+        //then
+        assertThat(posts).hasSize(1);
+    }
+
+    @DisplayName("게시물에 없는 tag 아이디로 검색 실패")
+    @Test
+    void find_notSavedTag_fail() {
+        //given
+        List<Long> notTagIds = List.of(-1L, -1234L, -8569L);
+        PostFilterCondition onlyTagFilter = new PostFilterCondition(notTagIds, null, null);
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTagFilter, coupleId);
+
+        //then
+        assertThat(posts).isEmpty();
+    }
+
+    @DisplayName("제목으로 검색 성공")
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"테스트", "제목", "서울", "제주", "창원"}
+    )
+    void search_title_success(String title) {
+        //given
+        PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, title, null);
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+
+        //then
+        assertThat(posts).hasSize(1);
+    }
+
+    @DisplayName("제목에 없는 단어로 검색 실패")
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"test", "seoul", "jeju", "changwon"}
+    )
+    void search_noTitle_fail(String noTitle) {
+        //given
+        PostFilterCondition onlyTitleFilter = new PostFilterCondition(null, noTitle, null);
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(onlyTitleFilter, coupleId);
+
+        //then
+        assertThat(posts).isEmpty();
+    }
+
+    @DisplayName("한번에 불러오는 사이즈는 20이다.")
+    @Test
+    void search_limitSize_20_success() {
+        //given
+        for (int i = 0; i < 30; i++) {
+            postRepository.save(createTestPost(couple, tags, postImages));
+        }
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(
+            new PostFilterCondition(null, null, null), coupleId);
+
+        //then
+        assertThat(posts).hasSize(20);
+    }
+
+    @DisplayName("모든 조건 검색 성공")
+    @Test
+    void search_filter_success() {
+        //given
+        List<Long> tagIds = tags.stream().map(Tag::getId).collect(Collectors.toList());
+
+        for (int i = 0; i < 30; i++) {
+            postRepository.save(createTestPost(couple, tags, postImages));
+        }
+
+        //when
+        List<Post> posts = postRepository.findPostsByFilterCondition(new PostFilterCondition(tagIds, "테스트", 54378537L),
+            coupleId);
+
+        //then
+        assertThat(posts).hasSize(20);
+
+    }
+
+    private Post createTestPost(Couple couple, List<Tag> tags, List<String> postImages) {
+
+        return Post.builder()
+            .couple(couple)
+            .title("테스트 제목 서울, 제주, 창원")
+            .content("게시물 내용")
+            .location(new Location(new BigDecimal("12.12312321"), new BigDecimal("12.12312321")))
+            .imageUrls(postImages)
+            .tags(tags)
+            .datingDate(LocalDate.of(2022, 02, 02))
+            .build();
+    }
+
+    private Couple createCouple() {
+        Couple couple = coupleRepository.save(new TCoupleBuilder().build());
+        return couple;
+    }
+
+    private List<String> createPostImages() {
+        return List.of("http://wooriemap.aws.com/1.jpg",
+            "http://wooriemap.aws.com/2.jpg",
+            "http://wooriemap.aws.com/3.jpg",
+            "http://wooriemap.aws.com/4.jpg",
+            "http://wooriemap.aws.com/5.jpg",
+            "http://wooriemap.aws.com/6.jpg",
+            "http://wooriemap.aws.com/7.jpg");
+    }
+
+    private List<Tag> createTestTags(Couple couple) {
+        tagRepository.saveAll(
+            List.of(new Tag("서울", "#null33", couple),
+                new Tag("대구", "#null33", couple),
+                new Tag("대전", "#null33", couple),
+                new Tag("부산", "#null33", couple),
+                new Tag("창원", "#null33", couple))
+        );
+
+        return tagRepository.findAllByCoupleId(couple.getId());
+
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/presentation/PostControllerTest.java
@@ -16,6 +16,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
@@ -50,6 +53,33 @@ class PostControllerTest extends AcceptanceTest {
             () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.CREATED.value()),
             () -> assertThat(response.getHeader(HttpHeaders.LOCATION)).isNotNull()
         );
+    }
+
+    @DisplayName("검색 API 성공")
+    @Test
+    void search_success() throws Exception {
+        //given
+        int savePostSize = 10;
+        for (int i = 0; i < savePostSize; i++) {
+            게시글_작성(coupleAccessToken, createPostRequest());
+        }
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("tagIds", "1,2,3,4,5,6,7,8,9,10");
+        params.add("title", "첫");
+
+        //when
+        MockHttpServletResponse response = mockMvc.perform(get("/api/couples/posts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, coupleAccessToken)
+                .params(params))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andDo(print())
+            .andReturn().getResponse();
+
+        //then
+        List posts = getResponseObject(response, List.class);
+        assertThat(posts).hasSize(savePostSize);
     }
 
     @DisplayName("게시물 단건 조회 성공")


### PR DESCRIPTION
## 요약
게시글 다건 조회 API 구현
<br><br>

## 작업 내용
- 제목, 태그로 검색기능 구현
- 필터가 없을 경우 전체 조회
- 페이징 사이즈 20으로 고정 정했음
- 태그 Response에 tagId 추가
<br><br>

## 참고 사항
### 조회 수정 후 쿼리문
```
select
        post1_.id as col_0_0_,
        post1_.title as col_1_0_,
        post1_.title as col_2_0_,
        post1_.created_date_time as col_3_0_,
        post1_.latitude as col_4_0_,
        post1_.longitude as col_5_0_ 
    from
        post_image postimage0_ 
    inner join
        post post1_ 
            on postimage0_.post_id=post1_.id 
    inner join
        post_tag posttags2_ 
            on post1_.id=posttags2_.post_id 
    inner join
        tag tag3_ 
            on posttags2_.tag_id=tag3_.id 
            and (
                tag3_.couple_id=2
            ) 
    where
        post1_.couple_id=2 
        and post1_.id<55 
        and (
            post1_.title like '%테%' escape '!'
        ) 
        and (
            tag3_.id in (
                6,7,8
            )
        ) 
    group by
        post1_.id 
    order by
        post1_.id desc limit 20 ;
```