### PR TITLE
[WOOR-188] fix: 태그 색상 길이 제한 값 변경

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/vo/TagColor.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/vo/TagColor.java
@@ -19,16 +19,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TagColor {
 
-    private static final int COLOR_LENGTH = 7;
-    private static final String PREFIX = "#";
+    private static final int COLOR_MIN = 7;
+    private static final int COLOR_MAX = 25;
 
-    @Column(name = "color", nullable = false, length = COLOR_LENGTH)
+    @Column(name = "color", nullable = false, length = COLOR_MAX)
     private String value;
 
     public TagColor(String color) {
         checkArgument(!StringUtils.isBlank(color), "태그 색깔은 비어있을 수 없습니다.");
-        checkArgument(color.trim().startsWith(PREFIX), format("태그 색깔은 {0}으로 시작해야합니다.", PREFIX));
-        checkArgument(color.trim().length() == COLOR_LENGTH, format("태그 색깔 길이는 {0}이여야 합니다.", COLOR_LENGTH));
+        checkArgument(color.trim().length() >= COLOR_MIN, format("태그 색깔 길이는 {0} 이상이어야 합니다.", COLOR_MIN));
+        checkArgument(color.trim().length() <= COLOR_MAX, format("태그 색깔 길이는 {0} 이하이어야 합니다.", COLOR_MAX));
         value = color.trim();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/vo/TagColor.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/vo/TagColor.java
@@ -19,16 +19,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TagColor {
 
-    private static final int COLOR_MIN = 7;
-    private static final int COLOR_MAX = 25;
+    private static final int COLOR_MIN_LENGTH = 7;
+    private static final int COLOR_MAX_LENGTH = 25;
 
-    @Column(name = "color", nullable = false, length = COLOR_MAX)
+    @Column(name = "color", nullable = false, length = COLOR_MAX_LENGTH)
     private String value;
 
     public TagColor(String color) {
         checkArgument(!StringUtils.isBlank(color), "태그 색깔은 비어있을 수 없습니다.");
-        checkArgument(color.trim().length() >= COLOR_MIN, format("태그 색깔 길이는 {0} 이상이어야 합니다.", COLOR_MIN));
-        checkArgument(color.trim().length() <= COLOR_MAX, format("태그 색깔 길이는 {0} 이하이어야 합니다.", COLOR_MAX));
+        checkArgument(color.trim().length() >= COLOR_MIN_LENGTH, format("태그 색깔 길이는 {0} 이상이어야 합니다.", COLOR_MIN_LENGTH));
+        checkArgument(color.trim().length() <= COLOR_MAX_LENGTH, format("태그 색깔 길이는 {0} 이하이어야 합니다.", COLOR_MAX_LENGTH));
         value = color.trim();
     }
 }

--- a/src/main/resources/db/migration/V3__modify_color_length_in_tag.sql
+++ b/src/main/resources/db/migration/V3__modify_color_length_in_tag.sql
@@ -1,0 +1,2 @@
+alter table tag
+    modify column color varchar(25) not null;

--- a/src/test/java/com/musseukpeople/woorimap/tag/domain/vo/TagColorTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/tag/domain/vo/TagColorTest.java
@@ -11,7 +11,7 @@ class TagColorTest {
 
     @DisplayName("태그 색깔 생성 성공")
     @ParameterizedTest(name = "색깔 : {0}")
-    @ValueSource(strings = {"#FFFFFF", "#123456", "   #800000"})
+    @ValueSource(strings = {"#FFFFFF", "#123456", "   #800000", "R(255)G(255)B(255)", "R(255) G(255) B(255)", "240, 248, 255"})
     void create_success(String color) {
         // given
         // when
@@ -30,18 +30,9 @@ class TagColorTest {
             .hasMessage("태그 색깔은 비어있을 수 없습니다.");
     }
 
-    @DisplayName("색깔이 헥사코드가 아님으로 인한 생성 실패")
-    @ParameterizedTest(name = "색깔 : {0}")
-    @ValueSource(strings = {"FFFFFF", "123456", "red", "blue"})
-    void create_notHexCode_fail(String color) {
-        assertThatThrownBy(() -> new TagColor(color))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("태그 색깔은 #으로 시작해야합니다.");
-    }
-
     @DisplayName("색깔이 지정 길이가 아님으로 인한 생성 실패")
     @ParameterizedTest(name = "색깔 : {0}")
-    @ValueSource(strings = {"#FFFFFFF", "   #FFFFF"})
+    @ValueSource(strings = {"#FFFFF", "   #FFFFF", "R ( 255 ) G ( 255 ) B ( 255 )"})
     void create_notEqualLength_fail(String color) {
         assertThatThrownBy(() -> new TagColor(color))
             .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
## 요약

- tag 정보 중 color 길이 제한 값을 최소 7, 최대 25으로 수정하였습니다. 
- 테스트 케이스 추가와 flyway sql 파일을 추가하였습니다. 
