### PR TITLE
[WOOR-216] feat: 게시물 생성, 수정 시 이벤트 발행 기능 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ logs
 
 ### Submodules ###
 src/main/resources/application-dev.yml
+src/main/resources/application-prod.yml
 
 ### .env ###
 .env

--- a/src/main/java/com/musseukpeople/woorimap/common/config/AsyncConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.musseukpeople.woorimap.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean("eventExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("Async EventExecutor");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
@@ -9,7 +9,10 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import com.musseukpeople.woorimap.notification.application.RedisMessageSubscriber;
 
 @Configuration
 @EnableRedisRepositories
@@ -42,6 +45,11 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
         return container;
+    }
+
+    @Bean
+    public MessageListenerAdapter messageStringListener(RedisMessageSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber);
     }
 
     @Bean

--- a/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/redis/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
@@ -37,9 +38,16 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         return redisTemplate;
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -35,13 +35,13 @@ public enum ErrorCode {
     NOT_MAPPING_COUPLE_MEMBER(HttpStatus.BAD_REQUEST, "CP005", "커플 멤버 정보 매핑 실패"),
 
     // InviteCode
-    NOT_FOUND_INVITE_CODE(HttpStatus.NOT_FOUND, "I001", "존재하지 않는 코드입니다."),
+    NOT_FOUND_INVITE_CODE(HttpStatus.NOT_FOUND, "N001", "존재하지 않는 코드입니다."),
 
     // Post
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "P001", "존재하지 않는 게시글입니다."),
     DUPLICATE_TAG(HttpStatus.BAD_REQUEST, "P002", "태그가 중복됩니다."),
     NOT_BELONG_TO_COUPLE(HttpStatus.FORBIDDEN, "P003", "해당하는 사용자의 게시물이 아닙니다."),
-    
+
     // Image
     INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "I001", "지원하지 않는 이미지 확장자입니다."),
     EXCEED_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "I002", "이미지 용량이 너무 큽니다.");

--- a/src/main/java/com/musseukpeople/woorimap/common/util/LocationUriUtil.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/util/LocationUriUtil.java
@@ -1,0 +1,19 @@
+package com.musseukpeople.woorimap.common.util;
+
+import java.net.URI;
+
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LocationUriUtil {
+
+    public static URI createLocationUri(Long id) {
+        return ServletUriComponentsBuilder.fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(id)
+            .toUri();
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/event/application/EventService.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/application/EventService.java
@@ -1,0 +1,25 @@
+package com.musseukpeople.woorimap.event.application;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventService {
+
+    private final Publisher publisher;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(PostEvent postEvent) {
+        publisher.publish(postEvent);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/event/application/Publisher.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/application/Publisher.java
@@ -1,0 +1,8 @@
+package com.musseukpeople.woorimap.event.application;
+
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+public interface Publisher {
+
+    void publish(PostEvent postEvent);
+}

--- a/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
@@ -9,21 +9,24 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.musseukpeople.woorimap.post.domain.Post;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostEvent implements Serializable {
 
     private static final long serialVersionUID = 5576120921802674645L;
 
-    private final Long sourceId;
-    private final Long destinationId;
-    private final Long postId;
-    private final String content;
+    private Long sourceId;
+    private Long destinationId;
+    private Long postId;
+    private String content;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private final LocalDateTime publishDateTime;
+    private LocalDateTime publishDateTime;
 
     public PostEvent(Long sourceId, Long destinationId, Long postId, String content, LocalDateTime publishDateTime) {
         this.sourceId = sourceId;

--- a/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
@@ -22,27 +22,36 @@ public class PostEvent implements Serializable {
     private Long sourceId;
     private Long destinationId;
     private Long postId;
+
+    private EventType eventType;
     private String content;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime publishDateTime;
 
-    public PostEvent(Long sourceId, Long destinationId, Long postId, String content, LocalDateTime publishDateTime) {
+    public PostEvent(Long sourceId, Long destinationId, Long postId, EventType eventType, String content,
+                     LocalDateTime publishDateTime) {
         this.sourceId = sourceId;
         this.destinationId = destinationId;
         this.postId = postId;
+        this.eventType = eventType;
         this.content = content;
         this.publishDateTime = publishDateTime;
     }
 
-    public static PostEvent of(Long sourceId, Post post) {
+    public static PostEvent of(Long sourceId, Post post, EventType eventType) {
         return new PostEvent(
             sourceId,
             post.getCouple().getOpponentMember(sourceId).getId(),
             post.getId(),
+            eventType,
             post.getContent(),
             LocalDateTime.now()
         );
+    }
+
+    public enum EventType {
+        POST_CREATED, POST_MODIFIED
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
@@ -1,0 +1,45 @@
+package com.musseukpeople.woorimap.event.domain;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.musseukpeople.woorimap.post.domain.Post;
+
+import lombok.Getter;
+
+@Getter
+public class PostEvent implements Serializable {
+
+    private static final long serialVersionUID = 5576120921802674645L;
+
+    private final Long sourceId;
+    private final Long destinationId;
+    private final Long postId;
+    private final String content;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private final LocalDateTime publishDateTime;
+
+    public PostEvent(Long sourceId, Long destinationId, Long postId, String content, LocalDateTime publishDateTime) {
+        this.sourceId = sourceId;
+        this.destinationId = destinationId;
+        this.postId = postId;
+        this.content = content;
+        this.publishDateTime = publishDateTime;
+    }
+
+    public static PostEvent of(Long sourceId, Post post) {
+        return new PostEvent(
+            sourceId,
+            post.getCouple().getOpponentMember(sourceId).getId(),
+            post.getId(),
+            post.getContent(),
+            LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/event/infrastructure/RedisPublisher.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/infrastructure/RedisPublisher.java
@@ -1,22 +1,28 @@
 package com.musseukpeople.woorimap.event.infrastructure;
 
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.stereotype.Component;
 
 import com.musseukpeople.woorimap.event.application.Publisher;
 import com.musseukpeople.woorimap.event.domain.PostEvent;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class RedisPublisher implements Publisher {
 
     public static final String CHANNEL_PREFIX = "channel/";
 
     private final RedisTemplate<String, PostEvent> redisTemplate;
+
+    public RedisPublisher(RedisTemplate<String, PostEvent> redisTemplate) {
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(PostEvent.class));
+        this.redisTemplate = redisTemplate;
+    }
 
     @Override
     public void publish(PostEvent postEvent) {

--- a/src/main/java/com/musseukpeople/woorimap/event/infrastructure/RedisPublisher.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/infrastructure/RedisPublisher.java
@@ -1,0 +1,26 @@
+package com.musseukpeople.woorimap.event.infrastructure;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.musseukpeople.woorimap.event.application.Publisher;
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisPublisher implements Publisher {
+
+    public static final String CHANNEL_PREFIX = "channel/";
+
+    private final RedisTemplate<String, PostEvent> redisTemplate;
+
+    @Override
+    public void publish(PostEvent postEvent) {
+        String channel = String.valueOf(postEvent.getDestinationId());
+        redisTemplate.convertAndSend(CHANNEL_PREFIX + channel, postEvent);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriber.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriber.java
@@ -1,0 +1,31 @@
+package com.musseukpeople.woorimap.notification.application;
+
+import java.io.IOException;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisMessageSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            PostEvent postEvent = objectMapper.readValue(message.getBody(), PostEvent.class);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new IllegalArgumentException("메시지를 변환하지 못했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/notification/fake/FakeNotificationController.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/fake/FakeNotificationController.java
@@ -1,0 +1,87 @@
+package com.musseukpeople.woorimap.notification.fake;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/api/fake")
+@Slf4j
+public class FakeNotificationController {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+    private final Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+    @GetMapping(value = "/subscribe/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@PathVariable("id") String memberId,
+                                @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+        String id = memberId + System.currentTimeMillis();
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+        log.error("id 값 : {}, 생성 sse : {}", id, sseEmitter);
+        sseEmitters.put(id, sseEmitter);
+        log.error("저장 sse : {}, {}", id, sseEmitter);
+
+        sseEmitter.onCompletion(() -> sseEmitters.remove(id));
+        sseEmitter.onTimeout(() -> sseEmitters.remove(id));
+
+        sendToClient(sseEmitter, id, "EventStream Created. [userId=" + id + "]");
+
+        return sseEmitter;
+    }
+
+    @PostMapping("/publish/{id}")
+    public void sendMessage(@PathVariable("id") String receiverId, @RequestBody MessageDto messageDto) {
+        Map<String, SseEmitter> sseEmitterMap = sseEmitters.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(receiverId))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        log.error("찾은 sse : {}", sseEmitterMap.size());
+
+        sseEmitterMap.forEach(
+            (key, sseEmitter) -> {
+                log.error("보내는 id : {} , sse : {}", key, sseEmitter);
+                sendToClient(sseEmitter, key, messageDto.getMessage());
+            }
+        );
+    }
+
+    private void sendToClient(SseEmitter sseEmitter, String id, Object data) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                .id(id)
+                .name("test")
+                .data(data));
+        } catch (IOException e) {
+            sseEmitters.remove(id);
+            throw new IllegalStateException("연결 오류");
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    static class MessageDto {
+
+        String message;
+
+        public MessageDto(String message) {
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/notification/presentation/fake/FakeNotificationController.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/presentation/fake/FakeNotificationController.java
@@ -1,4 +1,4 @@
-package com.musseukpeople.woorimap.notification.fake;
+package com.musseukpeople.woorimap.notification.presentation.fake;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -39,10 +39,6 @@ public class PostFacade {
         return post.getId();
     }
 
-    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
-        return postService.searchPosts(postFilterCondition, coupleId);
-    }
-
     @Transactional
     public Long modifyPost(LoginMember loginMember, Long postId, EditPostRequest editPostRequest) {
         Couple couple = coupleService.getCoupleById(loginMember.getCoupleId());
@@ -69,5 +65,9 @@ public class PostFacade {
             throw new PostNotBelongToCoupleException(coupleId, postId, ErrorCode.NOT_BELONG_TO_COUPLE);
         }
         return PostResponse.from(post);
+    }
+
+    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
+        return postService.searchPosts(postFilterCondition, coupleId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -33,7 +33,9 @@ public class PostFacade {
     public Long createPost(Long coupleId, CreatePostRequest createPostRequest) {
         Couple couple = coupleService.getCoupleById(coupleId);
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
-        return postService.createPost(couple, tags.getList(), createPostRequest);
+
+        Post post = postService.createPost(couple, tags.getList(), createPostRequest);
+        return post.getId();
     }
 
     public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
@@ -44,7 +46,9 @@ public class PostFacade {
     public Long modifyPost(Long coupleId, Long postId, EditPostRequest editPostRequest) {
         Couple couple = coupleService.getCoupleById(coupleId);
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
-        return postService.modifyPost(tags.getList(), postId, editPostRequest);
+
+        Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);
+        return post.getId();
     }
 
     @Transactional

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.application.CoupleService;
 import com.musseukpeople.woorimap.couple.domain.Couple;
@@ -30,8 +31,8 @@ public class PostFacade {
     private final CoupleService coupleService;
 
     @Transactional
-    public Long createPost(Long coupleId, CreatePostRequest createPostRequest) {
-        Couple couple = coupleService.getCoupleById(coupleId);
+    public Long createPost(LoginMember loginMember, CreatePostRequest createPostRequest) {
+        Couple couple = coupleService.getCoupleById(loginMember.getCoupleId());
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
 
         Post post = postService.createPost(couple, tags.getList(), createPostRequest);
@@ -43,8 +44,8 @@ public class PostFacade {
     }
 
     @Transactional
-    public Long modifyPost(Long coupleId, Long postId, EditPostRequest editPostRequest) {
-        Couple couple = coupleService.getCoupleById(coupleId);
+    public Long modifyPost(LoginMember loginMember, Long postId, EditPostRequest editPostRequest) {
+        Couple couple = coupleService.getCoupleById(loginMember.getCoupleId());
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
 
         Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -2,6 +2,7 @@ package com.musseukpeople.woorimap.post.application;
 
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +10,7 @@ import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.couple.application.CoupleService;
 import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.event.domain.PostEvent;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
@@ -29,6 +31,7 @@ public class PostFacade {
     private final PostService postService;
     private final TagService tagService;
     private final CoupleService coupleService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Long createPost(LoginMember loginMember, CreatePostRequest createPostRequest) {
@@ -36,6 +39,7 @@ public class PostFacade {
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
 
         Post post = postService.createPost(couple, tags.getList(), createPostRequest);
+        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post));
         return post.getId();
     }
 
@@ -45,6 +49,7 @@ public class PostFacade {
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
 
         Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);
+        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post));
         return post.getId();
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.post.application;
 
+import static com.musseukpeople.woorimap.event.domain.PostEvent.EventType.*;
+
 import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -39,7 +41,7 @@ public class PostFacade {
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
 
         Post post = postService.createPost(couple, tags.getList(), createPostRequest);
-        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post));
+        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post, POST_CREATED));
         return post.getId();
     }
 
@@ -49,7 +51,7 @@ public class PostFacade {
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
 
         Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);
-        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post));
+        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post, POST_CREATED));
         return post.getId();
     }
 

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
@@ -26,9 +26,9 @@ public class PostService {
     private final PostRepository postRepository;
 
     @Transactional
-    public Long createPost(Couple couple, List<Tag> tags, CreatePostRequest createPostRequest) {
+    public Post createPost(Couple couple, List<Tag> tags, CreatePostRequest createPostRequest) {
         Post post = createPostRequest.toPost(couple, tags);
-        return postRepository.save(post).getId();
+        return postRepository.save(post);
     }
 
     public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
@@ -37,7 +37,7 @@ public class PostService {
     }
 
     @Transactional
-    public Long modifyPost(List<Tag> tags, Long postId, EditPostRequest editPostRequest) {
+    public Post modifyPost(List<Tag> tags, Long postId, EditPostRequest editPostRequest) {
         Post post = getPostById(postId);
 
         post.changeTitle(editPostRequest.getTitle());
@@ -47,7 +47,7 @@ public class PostService {
         post.changePostImages(editPostRequest.getImageUrls());
         post.changePostTags(tags);
 
-        return post.getId();
+        return post;
     }
 
     public Post getPostWithFetchById(Long id) {

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostService.java
@@ -31,11 +31,6 @@ public class PostService {
         return postRepository.save(post);
     }
 
-    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
-        List<Post> posts = postRepository.findPostsByFilterCondition(postFilterCondition, coupleId);
-        return PostSearchResponse.from(posts);
-    }
-
     @Transactional
     public Post modifyPost(List<Tag> tags, Long postId, EditPostRequest editPostRequest) {
         Post post = getPostById(postId);
@@ -50,6 +45,16 @@ public class PostService {
         return post;
     }
 
+    @Transactional
+    public void removePost(Long postId) {
+        postRepository.deleteById(postId);
+    }
+
+    public List<PostSearchResponse> searchPosts(PostFilterCondition postFilterCondition, Long coupleId) {
+        List<Post> posts = postRepository.findPostsByFilterCondition(postFilterCondition, coupleId);
+        return PostSearchResponse.from(posts);
+    }
+
     public Post getPostWithFetchById(Long id) {
         return postRepository.findPostWithFetchById(id)
             .orElseThrow(() -> new NotFoundPostException(ErrorCode.NOT_FOUND_POST, id));
@@ -58,10 +63,5 @@ public class PostService {
     public Post getPostById(Long id) {
         return postRepository.findById(id)
             .orElseThrow(() -> new NotFoundPostException(ErrorCode.NOT_FOUND_POST, id));
-    }
-
-    @Transactional
-    public void removePost(Long postId) {
-        postRepository.deleteById(postId);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
@@ -1,6 +1,7 @@
 package com.musseukpeople.woorimap.post.presentation;
 
-import java.net.URI;
+import static com.musseukpeople.woorimap.common.util.LocationUriUtil.*;
+
 import java.util.List;
 
 import javax.validation.Valid;
@@ -14,7 +15,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.musseukpeople.woorimap.auth.aop.OnlyCouple;
 import com.musseukpeople.woorimap.auth.domain.login.Login;
@@ -45,7 +45,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<Void>> createPost(@Valid @RequestBody CreatePostRequest createPostRequest,
                                                         @Login LoginMember loginMember) {
         Long postId = postFacade.createPost(loginMember, createPostRequest);
-        return ResponseEntity.created(createURI(postId)).build();
+        return ResponseEntity.created(createLocationUri(postId)).build();
     }
 
     @Operation(summary = "게시글 다건 조회", description = "게시물 다건 조회 및 검색 API입니다.")
@@ -84,12 +84,5 @@ public class PostController {
                                                         @PathVariable("postId") Long postId) {
         postFacade.removePost(loginMember.getCoupleId(), postId);
         return ResponseEntity.noContent().build();
-    }
-
-    private URI createURI(Long id) {
-        return ServletUriComponentsBuilder.fromCurrentRequest()
-            .path("/{id}")
-            .buildAndExpand(id)
-            .toUri();
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/presentation/PostController.java
@@ -6,8 +6,8 @@ import java.util.List;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -24,8 +24,8 @@ import com.musseukpeople.woorimap.post.application.PostFacade;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
-import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 import com.musseukpeople.woorimap.post.application.dto.response.PostResponse;
+import com.musseukpeople.woorimap.post.application.dto.response.PostSearchResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -44,8 +44,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createPost(@Valid @RequestBody CreatePostRequest createPostRequest,
                                                         @Login LoginMember loginMember) {
-        Long coupleId = loginMember.getCoupleId();
-        Long postId = postFacade.createPost(coupleId, createPostRequest);
+        Long postId = postFacade.createPost(loginMember, createPostRequest);
         return ResponseEntity.created(createURI(postId)).build();
     }
 
@@ -74,8 +73,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<Void>> modifyPost(@Valid @RequestBody EditPostRequest editPostRequest,
                                                         @Login LoginMember loginMember,
                                                         @PathVariable("postId") Long postId) {
-        Long coupleId = loginMember.getCoupleId();
-        postFacade.modifyPost(coupleId, postId, editPostRequest);
+        postFacade.modifyPost(loginMember, postId, editPostRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/com/musseukpeople/woorimap/event/application/EventServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/event/application/EventServiceTest.java
@@ -1,0 +1,37 @@
+package com.musseukpeople.woorimap.event.application;
+
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Mock
+    private Publisher publisher;
+
+    @DisplayName("이벤트 발행 성공")
+    @Test
+    void publishEvent_success() {
+        // given
+        PostEvent postEvent = new PostEvent(1L, 2L, 1L, "타이틀", LocalDateTime.now());
+
+        // when
+        eventService.publishEvent(postEvent);
+
+        // then
+        then(publisher).should(times(1)).publish(any());
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/event/application/EventServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/event/application/EventServiceTest.java
@@ -26,7 +26,7 @@ class EventServiceTest {
     @Test
     void publishEvent_success() {
         // given
-        PostEvent postEvent = new PostEvent(1L, 2L, 1L, "타이틀", LocalDateTime.now());
+        PostEvent postEvent = new PostEvent(1L, 2L, 1L, PostEvent.EventType.POST_CREATED, "타이틀", LocalDateTime.now());
 
         // when
         eventService.publishEvent(postEvent);

--- a/src/test/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriberTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriberTest.java
@@ -1,0 +1,54 @@
+package com.musseukpeople.woorimap.notification.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.musseukpeople.woorimap.event.domain.PostEvent;
+
+class RedisMessageSubscriberTest {
+
+    private RedisMessageSubscriber redisMessageSubscriber;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        redisMessageSubscriber = new RedisMessageSubscriber(objectMapper);
+    }
+
+    @DisplayName("이벤트 수신 성공")
+    @Test
+    void onMessage_success() throws JsonProcessingException {
+        // given
+        PostEvent postEvent = new PostEvent(1L, 2L, 1L, "test", LocalDateTime.now());
+        Message message = new DefaultMessage("2L".getBytes(), objectMapper.writeValueAsBytes(postEvent));
+
+        // when
+        // then
+        assertDoesNotThrow(() -> redisMessageSubscriber.onMessage(message, "test".getBytes()));
+    }
+
+    @DisplayName("이벤트 타입이 다름으로 인한 실패")
+    @Test
+    void onMessage_invalidMessageType_fail() {
+        // given
+        String event = "invalidMessageType";
+        Message message = new DefaultMessage("2L".getBytes(), event.getBytes());
+
+        // when
+        // then
+        assertThatThrownBy(() -> redisMessageSubscriber.onMessage(message, "test".getBytes()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("메시지를 변환하지 못했습니다.");
+    }
+}

--- a/src/test/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriberTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/application/RedisMessageSubscriberTest.java
@@ -30,7 +30,7 @@ class RedisMessageSubscriberTest {
     @Test
     void onMessage_success() throws JsonProcessingException {
         // given
-        PostEvent postEvent = new PostEvent(1L, 2L, 1L, "test", LocalDateTime.now());
+        PostEvent postEvent = new PostEvent(1L, 2L, 1L, PostEvent.EventType.POST_CREATED, "test", LocalDateTime.now());
         Message message = new DefaultMessage("2L".getBytes(), objectMapper.writeValueAsBytes(postEvent));
 
         // when

--- a/src/test/java/com/musseukpeople/woorimap/post/application/PostFacadeTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/application/PostFacadeTest.java
@@ -198,16 +198,22 @@ class PostFacadeTest extends IntegrationTest {
     private LoginMember createCoupleMember() {
         Member inviter = new TMemberBuilder().email("inviter1@gmail.com").build();
         Member receiver = new TMemberBuilder().email("receiver1@gmail.com").build();
-        List<Member> members = memberRepository.saveAll(List.of(inviter, receiver));
-        Long coupleId = coupleRepository.save(new Couple(LocalDate.now(), new CoupleMembers(members))).getId();
-        return new LoginMember(receiver.getId(), coupleId, "accessToken");
+        List<Member> members = List.of(inviter, receiver);
+        memberRepository.saveAll(members);
+        Couple couple = coupleRepository.save(new Couple(LocalDate.now(), new CoupleMembers(members)));
+        members.forEach(member -> member.changeCouple(couple));
+        memberRepository.saveAll(members);
+        return new LoginMember(receiver.getId(), couple.getId(), "accessToken");
     }
 
     private LoginMember createOtherCoupleMember() {
         Member inviter = new TMemberBuilder().email("inviter2@gmail.com").build();
         Member receiver = new TMemberBuilder().email("receiver2@gmail.com").build();
-        List<Member> members = memberRepository.saveAll(List.of(inviter, receiver));
-        Long coupleId = coupleRepository.save(new Couple(LocalDate.now(), new CoupleMembers(members))).getId();
-        return new LoginMember(receiver.getId(), coupleId, "accessToken");
+        List<Member> members = List.of(inviter, receiver);
+        memberRepository.saveAll(members);
+        Couple couple = coupleRepository.save(new Couple(LocalDate.now(), new CoupleMembers(members)));
+        members.forEach(member -> member.changeCouple(couple));
+        memberRepository.saveAll(members);
+        return new LoginMember(receiver.getId(), couple.getId(), "accessToken");
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
@@ -23,8 +23,6 @@ import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
-import com.musseukpeople.woorimap.post.domain.Post;
-import com.musseukpeople.woorimap.post.domain.PostRepository;
 import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.EditPostRequest;
 import com.musseukpeople.woorimap.post.application.dto.request.PostFilterCondition;
@@ -180,7 +178,7 @@ class PostServiceTest extends IntegrationTest {
         List<Tag> tags = List.of(new Tag("seoul", "#FFFFFF", couple), new Tag("cafe", "#FFFFFF", couple));
         tagRepository.saveAll(tags);
         CreatePostRequest request = createPostRequest();
-        Long postId = postService.createPost(couple, tags, request);
+        Long postId = postService.createPost(couple, tags, request).getId();
 
         // when
         postService.removePost(postId);

--- a/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
@@ -74,7 +74,7 @@ class PostServiceTest extends IntegrationTest {
         CreatePostRequest request = createPostRequest();
 
         // when
-        Long postId = postService.createPost(couple, tags, request);
+        Long postId = postService.createPost(couple, tags, request).getId();
 
         // then
         assertThat(postId).isPositive();
@@ -143,13 +143,13 @@ class PostServiceTest extends IntegrationTest {
         List<Tag> tags = List.of(new Tag("seoul", "#FFFFFF", couple), new Tag("cafe", "#FFFFFF", couple));
         tagRepository.saveAll(tags);
         CreatePostRequest request = createPostRequest();
-        Long postId = postService.createPost(couple, tags, request);
+        Long postId = postService.createPost(couple, tags, request).getId();
 
         List<Tag> updateTags = new ArrayList<>();
         EditPostRequest editPostRequest = editPostRequest();
 
         // when
-        Long updatePostId = postService.modifyPost(updateTags, postId, editPostRequest);
+        Long updatePostId = postService.modifyPost(updateTags, postId, editPostRequest).getId();
 
         // then
         assertThat(postId).isEqualTo(updatePostId);
@@ -163,7 +163,7 @@ class PostServiceTest extends IntegrationTest {
         List<Tag> tags = List.of(new Tag("seoul", "#FFFFFF", couple), new Tag("cafe", "#FFFFFF", couple));
         tagRepository.saveAll(tags);
         CreatePostRequest request = createPostRequest();
-        Long postId = postService.createPost(couple, tags, request);
+        Long postId = postService.createPost(couple, tags, request).getId();
         entityManager.clear();
 
         // when


### PR DESCRIPTION
## 요약
- 게시물 생성, 수정 시 이벤트 발행 기능 구현 

<br><br>

## 작업 내용
- 이벤트 처리를 위해서 Service 단에서는 엔티티를 반환하도록 하고 Facade에서 나갈 때 변환을 하거나 아이디 값만 반환하도록 했습니다. ( f4149147a03d1ad2f06240ea6dfb4b5bd00b49ff, 8c0b84d177760a236ec1aca8132d62fe4b15b351) 
- 이벤트 발행 기능 구현 (cabd0303a706b3c960196dde56bdbe319d9c53a0) 
  - `ApplicationEventPulisher` 를 통해 발행합니다.
  - 이벤트 객체  ( eff7dc74552a38279ed798f455fa7f681aba6948 ) 
-  이벤트 리스너 구현 (85bbcb135adfe2fb436258b2f1519e011a14ec96 ) 
  - `ApplicationEventPulisher`를 통해 발행되면 발행된 이벤트를 파라미터로 받아 실행되게 됩니다. 
  - `@TransactionalEventListener`를 사용한 이유는 게시물이 영속화가 되어야지 이벤트가 발행되는 게 맞다고 생각되어 AFTER_COMMIT 옵션을 주었습니다, ( 사실 기본값이라 생략해도 되지만 조금 더 명확하게 보여주기 위해 놔두었습니다. ) 
  - 이후 `@Async`를 통해 비동기로 진행하도록 했습니다. 
- 레디스 pub 구현 ( 88f98243db2d75d989f5103c9f75ea039f028f0b ) 
  - 이벤트 리스너로 받은 이벤트를 pub 기능입니다. 
  - 채널은 일단 channel/{알림받을 회원 ID} 입니다. 
  - `여기서 조금 고민되는 점은 PostEvent를 바로 뿌릴지 아니면 Dto로 변환해서 뿌릴지 조금 고민이 됩니다. 의견 부탁드립니다!!`   
- 레디스 sub 구현 ( 76a5a512434bb24b7f82b2d1b5937225c0d93286 ) 
  - 이후 알림쪽에서 메시지를 받아 변환 후 클라이언트에게 전달하면 됩니다.   


<br><br>

## 참고 사항
- PR 단위가 커질 것 같아 알림부분과 이벤트 부분을 나눠서 구현하겠습니다.
- 또한, 커스텀 예외를 사용하지 않은 이유는 후에 서버를 분리할 수 있어서 일단 기본 예외를 사용했습니다.
<br><br>
