### PR TITLE
[WOOR-251] fix: 이미지 중복 제거 못하는 문제 해결

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/post/domain/PostRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/domain/PostRepository.java
@@ -11,7 +11,6 @@ import com.musseukpeople.woorimap.post.infrastructure.PostQueryRepository;
 public interface PostRepository extends JpaRepository<Post, Long>, PostQueryRepository {
 
     @Query("SELECT p FROM Post p "
-        + "JOIN FETCH p.postImages.postImages "
         + "JOIN FETCH p.postTags.postTags pt "
         + "JOIN FETCH pt.tag "
         + "JOIN FETCH p.couple "

--- a/src/test/java/com/musseukpeople/woorimap/common/util/ImageUtilTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/common/util/ImageUtilTest.java
@@ -13,7 +13,7 @@ class ImageUtilTest {
     @Test
     void isImageUrl_success() {
         // given
-        String url = "https://main.dwkg3ddyxqleg.amplifyapp.com/8c7f4d11b6e0b8ac08f0.png";
+        String url = "https://www.google.com/images/branding/googlelogo/2x/googlelogo_light_color_272x92dp.png";
 
         // when
         boolean result = ImageUtil.isImageUrl(url);


### PR DESCRIPTION
## 요약
- 이미지 중복 제거 못하는 문제 해결

<br><br>

## 작업 내용
- 포스트 이미지 FETCH JOIN 제거 
- DTO 변환 시 SELECT 이미지 쿼리 나가도록 변경

<br><br>

## 참고 사항
- [노션 보기](https://www.notion.so/backend-devcourse/JPA-fetch-join-51a3582a7d44486585d44ec4f953f933)
  - 정리를 아직 못해서 정리 후에 다시 말씀드리겠습니다! 

<br><br>
