### PR TITLE
[WOO-249] feat: 읽지 않은 알림 조회 API 구현 

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
@@ -2,8 +2,10 @@ package com.musseukpeople.woorimap.notification.application;
 
 import static com.musseukpeople.woorimap.notification.domain.Notification.*;
 import static java.lang.String.*;
+import static java.util.stream.Collectors.*;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -79,6 +81,13 @@ public class NotificationService {
             .orElseThrow(() -> new NotFoundNotificationException(id, ErrorCode.NOT_FOUND_NOTIFICATION));
 
         notification.read();
+    }
+
+    public List<NotificationResponse> getUnreadNotifications(Long memberId) {
+        List<Notification> notifications = notificationRepository.findUnreadAllByMemerId(memberId);
+        return notifications.stream()
+            .map(NotificationResponse::from)
+            .collect(toList());
     }
 
     private boolean hasLostEvent(String lastEventId) {

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
@@ -84,7 +84,7 @@ public class NotificationService {
     }
 
     public List<NotificationResponse> getUnreadNotifications(Long memberId) {
-        List<Notification> notifications = notificationRepository.findUnreadAllByMemerId(memberId);
+        List<Notification> notifications = notificationRepository.findUnreadAllByMemberId(memberId);
         return notifications.stream()
             .map(NotificationResponse::from)
             .collect(toList());

--- a/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
@@ -1,6 +1,13 @@
 package com.musseukpeople.woorimap.notification.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n WHERE n.receiverId = :id AND n.isRead = false ")
+    List<Notification> findUnreadAllByMemerId(@Param("id") Long id);
 }

--- a/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.repository.query.Param;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     @Query("SELECT n FROM Notification n WHERE n.receiverId = :id AND n.isRead = false ")
-    List<Notification> findUnreadAllByMemerId(@Param("id") Long id);
+    List<Notification> findUnreadAllByMemberId(@Param("id") Long id);
 }

--- a/src/main/java/com/musseukpeople/woorimap/notification/presentation/NotificationController.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/presentation/NotificationController.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.notification.presentation;
 
+import java.util.List;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,8 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.musseukpeople.woorimap.auth.aop.LoginRequired;
+import com.musseukpeople.woorimap.auth.domain.login.Login;
 import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
+import com.musseukpeople.woorimap.common.model.ApiResponse;
 import com.musseukpeople.woorimap.notification.application.NotificationService;
+import com.musseukpeople.woorimap.notification.application.dto.response.NotificationResponse;
 import com.musseukpeople.woorimap.notification.presentation.resolver.LoginForNoti;
 import com.musseukpeople.woorimap.notification.presentation.resolver.LoginRequiredForNoti;
 
@@ -34,6 +39,13 @@ public class NotificationController {
     public SseEmitter subscribe(@LoginForNoti LoginMember loginMember,
                                 @RequestHeader(value = "last-event-id", required = false, defaultValue = "") String lastEventId) {
         return notificationService.subscribe(loginMember.getId(), lastEventId);
+    }
+
+    @Operation(summary = "알림 조회", description = "읽지 않은 알림 조회 API입니다.")
+    @GetMapping("/notifications")
+    @LoginRequired
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> showNotification(@Login LoginMember loginMember) {
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "알림 읽음", description = "알림 읽음 API입니다.")

--- a/src/main/java/com/musseukpeople/woorimap/notification/presentation/NotificationController.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/presentation/NotificationController.java
@@ -44,8 +44,9 @@ public class NotificationController {
     @Operation(summary = "알림 조회", description = "읽지 않은 알림 조회 API입니다.")
     @GetMapping("/notifications")
     @LoginRequired
-    public ResponseEntity<ApiResponse<List<NotificationResponse>>> showNotification(@Login LoginMember loginMember) {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> showNotifications(@Login LoginMember loginMember) {
+        List<NotificationResponse> notifications = notificationService.getUnreadNotifications(loginMember.getId());
+        return ResponseEntity.ok(new ApiResponse<>(notifications));
     }
 
     @Operation(summary = "알림 읽음", description = "알림 읽음 API입니다.")

--- a/src/main/resources/db/migration/V5__add_foreign_key_to_notification.sql
+++ b/src/main/resources/db/migration/V5__add_foreign_key_to_notification.sql
@@ -1,0 +1,7 @@
+alter table notification
+    add constraint fk_receive_member_to_notification
+        foreign key (receive_member_id) references member (id),
+    add constraint fk_send_member_to_notification
+        foreign key (send_member_id) references member (id),
+    add constraint fk_content_to_notification
+        foreign key (content_id) references post (id);

--- a/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import com.musseukpeople.woorimap.common.exception.ErrorResponse;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.notification.application.dto.response.NotificationResponse;
 import com.musseukpeople.woorimap.notification.domain.Notification;
 import com.musseukpeople.woorimap.notification.domain.NotificationRepository;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
@@ -29,7 +32,7 @@ class NotificationControllerTest extends AcceptanceTest {
     @Test
     void subscribe_success() throws Exception {
         // given
-        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test")).substring(6);
+        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
 
         // when
         MockHttpServletResponse response = mockMvc.perform(get("/api/subscribe")
@@ -47,7 +50,7 @@ class NotificationControllerTest extends AcceptanceTest {
     void readNotification_success() throws Exception {
         // given
         String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
-        Long notificationId = getNotificationId();
+        Long notificationId = createNotification();
 
         // when
         MockHttpServletResponse response = readNotification(accessToken, notificationId);
@@ -58,10 +61,10 @@ class NotificationControllerTest extends AcceptanceTest {
 
     @DisplayName("존재 하지 않는 알림으로 인한 읽음 처리 실패")
     @Test
-    void readNotification_notFound_fail() throws Exception {
+    void readNotification_notFound_success() throws Exception {
         // given
         String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
-        Long notificationId = 100L;
+        Long notificationId = 1L;
 
         // when
         MockHttpServletResponse response = readNotification(accessToken, notificationId);
@@ -74,15 +77,35 @@ class NotificationControllerTest extends AcceptanceTest {
         );
     }
 
-    private Long getNotificationId() {
+    @DisplayName("알림 조회 성공")
+    @Test
+    void showNotification() throws Exception {
+        // given
+        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
+        readNotification(accessToken, createNotification());
+        createNotification();
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(get("/api/notifications")
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andReturn().getResponse();
+
+        // then
+        List<NotificationResponse> notificationResponses = getResponseList(response, NotificationResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(notificationResponses).hasSize(1)
+        );
+    }
+
+    private Long createNotification() {
         return notificationRepository.save(new Notification(1L, 1L, 1L, POST_CREATED, "test")).getId();
     }
 
     private MockHttpServletResponse readNotification(String accessToken, Long notificationId) throws Exception {
         return mockMvc.perform(patch("/api/notifications/{id}", notificationId)
                 .header(HttpHeaders.AUTHORIZATION, accessToken))
-            .andDo(print())
             .andReturn().getResponse();
     }
-
 }

--- a/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
@@ -32,7 +32,7 @@ class NotificationControllerTest extends AcceptanceTest {
     @Test
     void subscribe_success() throws Exception {
         // given
-        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
+        String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test")).substring(6);
 
         // when
         MockHttpServletResponse response = mockMvc.perform(get("/api/subscribe")

--- a/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
@@ -64,7 +64,7 @@ class NotificationControllerTest extends AcceptanceTest {
     void readNotification_notFound_success() throws Exception {
         // given
         String accessToken = 회원가입_토큰(new SignupRequest("test@gmail.com", "!Test1234", "test"));
-        Long notificationId = 1L;
+        Long notificationId = 100L;
 
         // when
         MockHttpServletResponse response = readNotification(accessToken, notificationId);

--- a/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
@@ -77,7 +77,7 @@ class NotificationControllerTest extends AcceptanceTest {
         );
     }
 
-    @DisplayName("알림 조회 성공")
+    @DisplayName("읽지 않은 알림 조회 성공")
     @Test
     void showNotification() throws Exception {
         // given


### PR DESCRIPTION
## 요약
-  읽지 않은 알림 조회 API 구현 
<br><br>

## 작업 내용
- 알림 조회 쿼리 구현 (8bc6bbece4df49db2be9730b9e4fa87e669e6d2e) 
- 알림 조회 기능 구현 ( 58f84ffb019c65738c4b2e9444c83c6132cd5a98) 

<br><br>

## 참고 사항
- 원래는 API를 통해 보낸 회원의 닉네임을 가져오려 했는데 알림 조회할 때마다 가져와야 해서 조금 고민이 됩니다. 
- 그냥 알림을 저장할 때 상대방은 닉네임으로 저장하도록 할까요?? 의견 부탁드립니다!!!
  - 아니면 이벤트 보낼때부터 닉네임으로?? 

<br><br>
