### PR TITLE
[WOOR-233] refactor: 알림 응답시 타입도 같이 보내도록 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ sonarqube {
         property "sonar.organization", "prgrms-web-devcourse"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
-        property "sonar.exclusions"."**.*Dto*, **.*common*, **.*Exception*, **.*Response*, **.*Request*"
+        property "sonar.exclusions", "**.*Dto*, **.*common*, **.*Exception*, **.*Response*, **.*Request*"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,7 @@ sonarqube {
         property "sonar.organization", "prgrms-web-devcourse"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+        property "sonar.exclusions"."**.*Dto*, **.*common*, **.*Exception*, **.*Response*, **.*Request*"
     }
 }
 

--- a/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
@@ -19,7 +19,7 @@ public class PostEvent implements Serializable {
 
     private static final long serialVersionUID = 5576120921802674645L;
 
-    private Long sourceId;
+    private String sourceNickName;
     private Long destinationId;
     private Long postId;
 
@@ -30,9 +30,9 @@ public class PostEvent implements Serializable {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime publishDateTime;
 
-    public PostEvent(Long sourceId, Long destinationId, Long postId, EventType eventType, String content,
+    public PostEvent(String sourceNickName, Long destinationId, Long postId, EventType eventType, String content,
                      LocalDateTime publishDateTime) {
-        this.sourceId = sourceId;
+        this.sourceNickName = sourceNickName;
         this.destinationId = destinationId;
         this.postId = postId;
         this.eventType = eventType;
@@ -42,7 +42,7 @@ public class PostEvent implements Serializable {
 
     public static PostEvent of(Long sourceId, Post post, EventType eventType) {
         return new PostEvent(
-            sourceId,
+            post.getCouple().getMyMember(sourceId).getNickName().getValue(),
             post.getCouple().getOpponentMember(sourceId).getId(),
             post.getId(),
             eventType,

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
@@ -100,7 +100,7 @@ public class NotificationService {
 
     private Notification createNotification(PostEvent postEvent) {
         return Notification.builder()
-            .senderId(postEvent.getSourceId())
+            .senderNickName(postEvent.getSourceNickName())
             .receiverId(postEvent.getDestinationId())
             .contentId(postEvent.getPostId())
             .content(postEvent.getContent())

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
@@ -31,7 +31,7 @@ public class NotificationResponse {
             notification.getId(),
             notification.getContentId(),
             notification.getNotificationType(),
-            String.valueOf(notification.getSenderId()),
+            notification.getSenderNickName(),
             notification.getContent()
         );
     }

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
@@ -1,5 +1,7 @@
 package com.musseukpeople.woorimap.notification.application.dto.response;
 
+import static com.musseukpeople.woorimap.notification.domain.Notification.*;
+
 import com.musseukpeople.woorimap.notification.domain.Notification;
 
 import lombok.AccessLevel;
@@ -12,12 +14,14 @@ public class NotificationResponse {
 
     private Long id;
     private Long contentId;
+    private NotificationType type;
     private String nickName;
     private String content;
 
-    public NotificationResponse(Long id, Long contentId, String nickName, String content) {
+    public NotificationResponse(Long id, Long contentId, NotificationType type, String nickName, String content) {
         this.id = id;
         this.contentId = contentId;
+        this.type = type;
         this.nickName = nickName;
         this.content = content;
     }
@@ -26,7 +30,7 @@ public class NotificationResponse {
         return new NotificationResponse(
             notification.getId(),
             notification.getContentId(),
-            // TODO : API를 통해 NickName 반환받도록 변경
+            notification.getNotificationType(),
             String.valueOf(notification.getSenderId()),
             notification.getContent()
         );

--- a/src/main/java/com/musseukpeople/woorimap/notification/domain/Notification.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/domain/Notification.java
@@ -29,8 +29,8 @@ public class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, name = "send_member_id")
-    private Long senderId;
+    @Column(nullable = false, name = "send_member_nick_name")
+    private String senderNickName;
 
     @Column(nullable = false, name = "receive_member_id")
     private Long receiverId;
@@ -53,8 +53,8 @@ public class Notification {
     private LocalDateTime createdDateTime;
 
     @Builder
-    public Notification(Long senderId, Long receiverId, Long contentId, NotificationType type, String content) {
-        this.senderId = senderId;
+    public Notification(String senderNickName, Long receiverId, Long contentId, NotificationType type, String content) {
+        this.senderNickName = senderNickName;
         this.receiverId = receiverId;
         this.contentId = contentId;
         this.notificationType = type;

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -37,7 +37,7 @@ public class PostFacade {
 
     @Transactional
     public Long createPost(LoginMember loginMember, CreatePostRequest createPostRequest) {
-        Couple couple = coupleService.getCoupleById(loginMember.getCoupleId());
+        Couple couple = coupleService.getCoupleWithMemberById(loginMember.getCoupleId());
         Tags tags = tagService.findOrCreateTags(couple, createPostRequest.getTags());
 
         Post post = postService.createPost(couple, tags.getList(), createPostRequest);
@@ -47,7 +47,7 @@ public class PostFacade {
 
     @Transactional
     public Long modifyPost(LoginMember loginMember, Long postId, EditPostRequest editPostRequest) {
-        Couple couple = coupleService.getCoupleById(loginMember.getCoupleId());
+        Couple couple = coupleService.getCoupleWithMemberById(loginMember.getCoupleId());
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
 
         Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);

--- a/src/main/resources/db/migration/V6__delete_foreign_key_to_notification.sql
+++ b/src/main/resources/db/migration/V6__delete_foreign_key_to_notification.sql
@@ -1,0 +1,4 @@
+alter table notification
+    drop constraint fk_receive_member_to_notification,
+    drop constraint fk_send_member_to_notification,
+    drop constraint fk_content_to_notification;

--- a/src/main/resources/db/migration/V6__delete_foreign_key_to_notification.sql
+++ b/src/main/resources/db/migration/V6__delete_foreign_key_to_notification.sql
@@ -1,4 +1,7 @@
 alter table notification
     drop constraint fk_receive_member_to_notification,
+    drop index fk_receive_member_to_notification,
     drop constraint fk_send_member_to_notification,
-    drop constraint fk_content_to_notification;
+    drop index fk_send_member_to_notification,
+    drop constraint fk_content_to_notification,
+    drop index fk_content_to_notification;

--- a/src/main/resources/db/migration/V7__change_senderId_colum_in_notification.sql
+++ b/src/main/resources/db/migration/V7__change_senderId_colum_in_notification.sql
@@ -1,0 +1,2 @@
+alter table notification
+    change column send_member_id send_member_nick_name varchar(255) not null;

--- a/src/main/resources/db/migration/V8__add_index_to_notification.sql
+++ b/src/main/resources/db/migration/V8__add_index_to_notification.sql
@@ -1,0 +1,2 @@
+CREATE INDEX receive_member_id_index ON notification (receive_member_id);
+

--- a/src/test/java/com/musseukpeople/woorimap/event/application/EventListenerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/event/application/EventListenerTest.java
@@ -1,8 +1,7 @@
 package com.musseukpeople.woorimap.event.application;
 
+import static java.time.LocalDateTime.*;
 import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +25,7 @@ class EventListenerTest {
     @Test
     void publishEvent_success() {
         // given
-        PostEvent postEvent = new PostEvent(1L, 2L, 1L, PostEvent.EventType.POST_CREATED, "타이틀", LocalDateTime.now());
+        PostEvent postEvent = new PostEvent("test", 2L, 1L, PostEvent.EventType.POST_CREATED, "타이틀", now());
 
         // when
         eventListener.publishEvent(postEvent);

--- a/src/test/java/com/musseukpeople/woorimap/notification/application/NotificationServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/application/NotificationServiceTest.java
@@ -1,12 +1,12 @@
 package com.musseukpeople.woorimap.notification.application;
 
 import static com.musseukpeople.woorimap.notification.domain.Notification.NotificationType.*;
+import static java.time.LocalDateTime.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +63,7 @@ class NotificationServiceTest {
         // given
         Long receiverId = 2L;
         SseEmitter mockSseEmitter = mock(SseEmitter.class);
-        PostEvent postEvent = new PostEvent(1L, receiverId, 1L, EventType.POST_CREATED, "test", LocalDateTime.now());
+        PostEvent postEvent = new PostEvent("test", receiverId, 1L, EventType.POST_CREATED, "test", now());
         given(emitterRepository.findAllStartWithByMemberId(anyString())).willReturn(
             Map.of(String.valueOf(receiverId), mockSseEmitter));
 
@@ -123,7 +123,7 @@ class NotificationServiceTest {
     public Notification createNotification(Long memberId) {
         return Notification.builder()
             .receiverId(memberId)
-            .senderId(1L)
+            .senderNickName("우리맵")
             .contentId(1L)
             .type(POST_CREATED)
             .content("test")

--- a/src/test/java/com/musseukpeople/woorimap/notification/application/message/RedisMessageSubscriberTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/application/message/RedisMessageSubscriberTest.java
@@ -1,10 +1,9 @@
 package com.musseukpeople.woorimap.notification.application.message;
 
+import static java.time.LocalDateTime.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,7 +33,7 @@ class RedisMessageSubscriberTest {
     @Test
     void onMessage_success() throws JsonProcessingException {
         // given
-        PostEvent postEvent = new PostEvent(1L, 2L, 1L, PostEvent.EventType.POST_CREATED, "test", LocalDateTime.now());
+        PostEvent postEvent = new PostEvent("test", 2L, 1L, PostEvent.EventType.POST_CREATED, "test", now());
         Message message = new DefaultMessage("2L".getBytes(), objectMapper.writeValueAsBytes(postEvent));
 
         // when

--- a/src/test/java/com/musseukpeople/woorimap/notification/domain/NotificationTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/domain/NotificationTest.java
@@ -14,14 +14,14 @@ class NotificationTest {
     @Test
     void create_success() {
         // given
-        Long senderId = 1L;
+        String senderNickName = "우리맵";
         Long receiverId = 2L;
         Long contentId = 1L;
         NotificationType notificationType = POST_CREATED;
         String content = "test";
 
         // when
-        Notification notification = new Notification(senderId, receiverId, contentId, notificationType, content);
+        Notification notification = new Notification(senderNickName, receiverId, contentId, notificationType, content);
 
         // then
         assertThat(notification).isNotNull();
@@ -31,7 +31,7 @@ class NotificationTest {
     @Test
     void read_success() {
         // given
-        Notification notification = new Notification(1L, 2L, 1L, POST_CREATED, "test");
+        Notification notification = new Notification("우리맵", 2L, 1L, POST_CREATED, "test");
 
         // when
         notification.read();

--- a/src/test/java/com/musseukpeople/woorimap/notification/infrastructure/EmitterRepositoryTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/infrastructure/EmitterRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.musseukpeople.woorimap.notification.infrastructure;
 
+import static com.musseukpeople.woorimap.notification.domain.Notification.NotificationType.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Map;
@@ -39,7 +40,7 @@ class EmitterRepositoryTest {
     void saveEventCache_success() {
         // given
         String id = "1";
-        NotificationResponse data = new NotificationResponse(1L, 1L, "test", "content");
+        NotificationResponse data = new NotificationResponse(1L, 1L, POST_CREATED, "test", "content");
 
         // when
         emitterRepository.saveEventCache(id, data);

--- a/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/notification/presentation/NotificationControllerTest.java
@@ -100,7 +100,7 @@ class NotificationControllerTest extends AcceptanceTest {
     }
 
     private Long createNotification() {
-        return notificationRepository.save(new Notification(1L, 1L, 1L, POST_CREATED, "test")).getId();
+        return notificationRepository.save(new Notification("우리맵", 1L, 1L, POST_CREATED, "test")).getId();
     }
 
     private MockHttpServletResponse readNotification(String accessToken, Long notificationId) throws Exception {


### PR DESCRIPTION
## 요약
- 알림 응답시 타입도 같이 보내도록 리팩토링
- 이벤트 발행 시 닉네임으로 보내도록 리팩토링

<br><br>

## 작업 내용
- 알림 응답시 타입도 같이 보내도록 변경 (daed0339d277988b457048844b74ea073ca6f8ac) 
- 이벤트 발행 시 발행한 회원의 닉네임으로 보내도록 변경 (d34f72c2be0bc694f1158e75e8d93c4c5209004f) 
  -  API로 할려 했지만 좀 더 간편한 방법으로 일단 하였습니다. 이부분에선 멘토님에게 한번 여쭤보고 리팩토링하면서 고치겠습니다. 
  - 추가적으로 게시글 등록, 수정 시 커플은 멤버를 fetch join해서 가져오도록 했습니다. (9bd517716bed811b4ed3ce227ccb6830edba17f6)  

<br><br>

## 참고 사항

<br><br>
