### PR TITLE
[WOOR-277] fix: 커플 해제시 외래키 문제로 인한 삭제 버그 해결

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
+++ b/src/main/java/com/musseukpeople/woorimap/couple/domain/Couple.java
@@ -3,6 +3,8 @@ package com.musseukpeople.woorimap.couple.domain;
 import static com.google.common.base.Preconditions.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -10,10 +12,13 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 import com.musseukpeople.woorimap.common.model.BaseEntity;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
 import com.musseukpeople.woorimap.member.domain.Member;
+import com.musseukpeople.woorimap.post.domain.Post;
+import com.musseukpeople.woorimap.tag.domain.Tag;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,6 +38,12 @@ public class Couple extends BaseEntity {
 
     @Embedded
     private CoupleMembers coupleMembers;
+
+    @OneToMany(mappedBy = "couple", orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "couple", orphanRemoval = true)
+    private List<Tag> tags = new ArrayList<>();
 
     public Couple(LocalDate startDate, CoupleMembers coupleMembers) {
         this(null, startDate, coupleMembers);
@@ -65,5 +76,13 @@ public class Couple extends BaseEntity {
 
     public boolean isSame(Couple couple) {
         return this.id.equals(couple.id);
+    }
+
+    public void addPost(Post post) {
+        this.posts.add(post);
+    }
+
+    public void addTag(Tag tag) {
+        this.tags.add(tag);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/post/domain/Post.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/domain/Post.java
@@ -67,6 +67,7 @@ public class Post extends BaseEntity {
     public Post(Couple couple, String title, String content, Location location, LocalDate datingDate,
                 List<String> imageUrls, List<Tag> tags) {
         this.couple = couple;
+        this.couple.addPost(this);
         this.title = title;
         this.content = content;
         this.location = location;

--- a/src/main/java/com/musseukpeople/woorimap/tag/domain/Tag.java
+++ b/src/main/java/com/musseukpeople/woorimap/tag/domain/Tag.java
@@ -44,6 +44,7 @@ public class Tag {
         this.name = name;
         this.color = color;
         this.couple = couple;
+        this.couple.addTag(this);
     }
 
     public boolean isSameName(Tag tag) {

--- a/src/test/java/com/musseukpeople/woorimap/couple/presentation/CoupleControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/couple/presentation/CoupleControllerTest.java
@@ -6,8 +6,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,8 @@ import com.musseukpeople.woorimap.couple.domain.InviteCodeRepository;
 import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
 import com.musseukpeople.woorimap.member.domain.Member;
 import com.musseukpeople.woorimap.member.domain.MemberRepository;
+import com.musseukpeople.woorimap.post.application.dto.request.CreatePostRequest;
+import com.musseukpeople.woorimap.tag.application.dto.request.TagRequest;
 import com.musseukpeople.woorimap.util.AcceptanceTest;
 
 class CoupleControllerTest extends AcceptanceTest {
@@ -38,9 +42,6 @@ class CoupleControllerTest extends AcceptanceTest {
     private static final String email = "test@gmail.com";
     private static final String password = "!Test1234";
     private static final String nickName = "test";
-
-    @Autowired
-    private CoupleRepository coupleRepository;
 
     @Autowired
     private InviteCodeRepository inviteCodeRepository;
@@ -206,6 +207,10 @@ class CoupleControllerTest extends AcceptanceTest {
     void removeCouple_success() throws Exception {
         //given
         String coupleToken = 커플_맺기_토큰(accessToken);
+        게시글_작성(coupleToken, createPostRequest());
+        게시글_작성(coupleToken, createPostRequest());
+        게시글_작성(coupleToken, createPostRequest());
+        게시글_작성(coupleToken, createPostRequest());
 
         //when
         mockMvc.perform(delete("/api/couples")
@@ -284,5 +289,21 @@ class CoupleControllerTest extends AcceptanceTest {
             .andExpect(status().isCreated())
             .andDo(print())
             .andReturn().getResponse();
+    }
+
+    private CreatePostRequest createPostRequest() {
+        return CreatePostRequest.builder()
+            .title("첫 이야기")
+            .content("<h1>첫 이야기.... </h1>")
+            .imageUrls(List.of("imageUrl1", "imageUrl2"))
+            .tags(List.of(
+                new TagRequest("서울", "#FFFFFF"),
+                new TagRequest("갬성", "#FFFFFF"),
+                new TagRequest("카페", "#FFFFFF")
+            ))
+            .datingDate(LocalDate.now())
+            .latitude(new BigDecimal("12.12312321"))
+            .longitude(new BigDecimal("122.3123121"))
+            .build();
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/application/PostServiceTest.java
@@ -86,8 +86,10 @@ class PostServiceTest extends IntegrationTest {
         tagRepository.saveAll(tags);
 
         // when
+        CreatePostRequest createPostRequest = createPostRequest();
+
         // then
-        assertThatThrownBy(() -> postService.createPost(couple, tags, createPostRequest()))
+        assertThatThrownBy(() -> postService.createPost(couple, tags, createPostRequest))
             .isInstanceOf(DuplicateTagException.class)
             .hasMessage("태그가 중복됩니다.");
     }
@@ -187,6 +189,28 @@ class PostServiceTest extends IntegrationTest {
         Optional<Post> foundPost = postRepository.findById(postId);
 
         assertThat(foundPost).isEmpty();
+    }
+
+    @DisplayName("커플 삭제시 해당 커플 게시물 모두 삭제")
+    @Test
+    void name() {
+        //given
+        List<Tag> tags = List.of(new Tag("seoul", "#FFFFFF", couple), new Tag("cafe", "#FFFFFF", couple));
+        tagRepository.saveAll(tags);
+        CreatePostRequest request = createPostRequest();
+        Long postId = postService.createPost(couple, tags, request).getId();
+
+        //when
+        Long coupleId = couple.getId();
+        coupleRepository.deleteById(coupleId);
+
+        List<Post> findPosts = postRepository.findPostsByFilterCondition(
+            new PostFilterCondition(null, null, null), coupleId);
+        List<Tag> findTags = tagRepository.findAllByCoupleId(coupleId);
+
+        //then
+        assertThat(findPosts).isEmpty();
+        assertThat(findTags).isEmpty();
     }
 
     private EditPostRequest editPostRequest() {

--- a/src/test/java/com/musseukpeople/woorimap/post/domain/PostTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/post/domain/PostTest.java
@@ -20,12 +20,13 @@ public class PostTest {
     @Test
     void createPost_fail() {
         // given
+        Couple couple = createCouple();
         List<Tag> tags = List.of();
         List<String> imageUrls = List.of("imageUrl1", "imageUrl2", "imageUrl3");
 
         // when
         // then
-        assertThatThrownBy(() -> getPost(imageUrls, tags))
+        assertThatThrownBy(() -> getPost(imageUrls, tags, couple))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("태그는 1개 이상 등록해야합니다");
     }
@@ -43,7 +44,7 @@ public class PostTest {
 
         // when
         // then
-        assertThatThrownBy(() -> getPost(imageUrls, tags))
+        assertThatThrownBy(() -> getPost(imageUrls, tags, couple))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("이미지는 1개 이상 등록해야합니다");
     }
@@ -68,17 +69,18 @@ public class PostTest {
 
         // when
         // then
-        assertThatThrownBy(() -> getPost(imageUrls, tags))
+        assertThatThrownBy(() -> getPost(imageUrls, tags, couple))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("이미지는 최대 5개 등록 가능합니다");
     }
 
-    private Post getPost(List<String> imageUrls, List<Tag> tags) {
+    private Post getPost(List<String> imageUrls, List<Tag> tags,Couple couple) {
         return Post.builder()
             .title("hi")
             .imageUrls(imageUrls)
             .datingDate(LocalDate.now())
             .tags(tags)
+            .couple(couple)
             .build();
     }
 


### PR DESCRIPTION
## 요약
커플 해제시 외래키 문제로 인한 삭제 버그 해결
<br><br>

## 작업 내용
- couple
  - post, tag 두개의 양방향 매핑
  - 연관관계 메소드 구현
- post, tag
  - couple 연관관계 메소드 추가

- Test
  - 커플 삭제시 post, postTag, Tag 모두 삭제 확인
<br><br>

## 참고 사항

<br><br>
