### PR TITLE
[WOOR-274] feat: 다중 이미지 업로드 비동기 처리 구현

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,10 +43,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build and analyze with Gradle
-        env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          ./gradlew test sonarqube
-          ./gradlew build
+      - name: Test with Gradle
+        run: ./gradlew --info test
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,4 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonarqube --info
+        run: |
+          ./gradlew test sonarqube
+          ./gradlew build


### PR DESCRIPTION
## 요약
* 다중 업로드 이미지 업로드 비동기로 처리 구현
<br><br>

## 작업 내용
* CompletableFuture을 이용해 요청을 한번에 다 보내고, 모든 요청이 끝나면 imageUrl들을 종합하는 방식으로 바꿨습니다.
<br><br>

## 참고 사항
96개의 이미지를 요청을 보내 소요 시간을 측정해봤습니다.
* 동기 처리 시 소요 시간: `11.37s`
![동기](https://user-images.githubusercontent.com/47207658/184475865-edf21eba-deab-4cfb-814f-1874460b1ae8.PNG)
* 비동기 처리 시 소요 시간: `2.82s`
![비동기](https://user-images.githubusercontent.com/47207658/184475880-4254caf9-7f9f-4b0f-8987-758d550d0fb7.PNG)
<br><br>
