### PR TITLE
[WOOR-282] feat: 비동기 처리 시 커스텀 스레드풀 사용하도록 수정

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/common/config/AsyncConfig.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.musseukpeople.woorimap.common.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,18 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("Async EventExecutor");
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean("imageExecutor")
+    public Executor getAsyncImageExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(20);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setThreadNamePrefix("Async ImageExecutor");
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
## 요약
이미지 업로드 비동기 처리 시 커스텀 스레드풀을 사용하도록 수정
<br><br>

## 작업 내용
* Config 클래스에 커스텀 스레드풀 추가
* 이미지 업로드 비동기 처리 시 타임아웃 추가
<br><br>

## 참고 사항
* 프론트쪽에서 다중 이미지 업로드 시 5개로 제한하므로, 디폴트 풀 사이즈를 5로 설정했습니다
  * 디폴트 풀사이즈를 적게 두고 더 요청이 오면 스레드를 늘려가는 방식으로 할 수 있지만, 5개정도면 미리 만들어놔도 문제가 없을거같아서 일케 했네요 
* CompletableFuture에서 최대 성능을 발휘하려면 커스텀 스레드풀을 사용하라는데, 저희는 이미지 업로드 시 최대 5개까지만 가능해서 커스텀 스레드풀을 사용해도 응답시간이 비슷하네요 ㅋㅋㅋ; 
  * 병렬 스트림으로도 테스트 해봤는데 다 또이또이하네유
  * 그래도 가장 최적화된..거같습니다
<br><br>
