### PR TITLE
[WOOR-230] feat: 커플 상태 변경 시 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/musseukpeople/woorimap/auth/aop/LoginMemberVerifier.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/aop/LoginMemberVerifier.java
@@ -6,7 +6,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
-import com.musseukpeople.woorimap.auth.exception.MemberAccessDeniedExcpetion;
+import com.musseukpeople.woorimap.auth.exception.MemberAccessDeniedException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class LoginMemberVerifier {
     public void checkSolo() {
         Authority authority = memberAuthorityContext.getAuthority();
         if (!Authority.SOLO.equals(authority)) {
-            throw new MemberAccessDeniedExcpetion(ErrorCode.HANDLE_ACCESS_DENIED);
+            throw new MemberAccessDeniedException(ErrorCode.HANDLE_ACCESS_DENIED);
         }
     }
 
@@ -30,7 +30,7 @@ public class LoginMemberVerifier {
     public void checkCouple() {
         Authority authority = memberAuthorityContext.getAuthority();
         if (!Authority.COUPLE.equals(authority)) {
-            throw new MemberAccessDeniedExcpetion(ErrorCode.HANDLE_ACCESS_DENIED);
+            throw new MemberAccessDeniedException(ErrorCode.HANDLE_ACCESS_DENIED);
         }
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/application/JwtProvider.java
@@ -4,8 +4,6 @@ import java.util.Date;
 
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 
-import io.jsonwebtoken.Claims;
-
 public interface JwtProvider {
 
     TokenDto createAccessToken(String payload, Long coupleId);
@@ -16,7 +14,7 @@ public interface JwtProvider {
 
     Date getExpiredDate(String token);
 
-    Claims getClaims(String token);
+    String getSubject(String token);
 
-    String getClaimName();
+    Long getCoupleId(String token);
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/exception/InvalidTokenRequestException.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/exception/InvalidTokenRequestException.java
@@ -1,0 +1,10 @@
+package com.musseukpeople.woorimap.auth.exception;
+
+import com.musseukpeople.woorimap.common.exception.BusinessException;
+import com.musseukpeople.woorimap.common.exception.ErrorCode;
+
+public class InvalidTokenRequestException extends BusinessException {
+    public InvalidTokenRequestException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+}

--- a/src/main/java/com/musseukpeople/woorimap/auth/exception/MemberAccessDeniedException.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/exception/MemberAccessDeniedException.java
@@ -3,9 +3,9 @@ package com.musseukpeople.woorimap.auth.exception;
 import com.musseukpeople.woorimap.common.exception.BusinessException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
-public class MemberAccessDeniedExcpetion extends BusinessException {
-    
-    public MemberAccessDeniedExcpetion(ErrorCode errorCode) {
+public class MemberAccessDeniedException extends BusinessException {
+
+    public MemberAccessDeniedException(ErrorCode errorCode) {
         super(errorCode.getMessage(), errorCode);
     }
 }

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -66,6 +66,13 @@ public class AuthController {
         return ResponseEntity.ok(new ApiResponse<>(accessToken));
     }
 
+    @Operation(summary = "커플용 엑세스 토큰 재발급", description = "커플 상태 변경 시 엑세스 토큰을 재발급 받습니다.")
+    @SecurityRequirement(name = "bearer")
+    @PostMapping("/couples/token")
+    public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshCoupleAccessToken(@RequestTokens JwtToken jwtToken) {
+        return ResponseEntity.ok().build();
+    }
+
     private void setTokenCookie(HttpServletResponse response, TokenDto tokenDto) {
         ResponseCookie cookie = CookieUtil.createTokenCookie(tokenDto);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/AuthController.java
@@ -70,7 +70,11 @@ public class AuthController {
     @SecurityRequirement(name = "bearer")
     @PostMapping("/couples/token")
     public ResponseEntity<ApiResponse<AccessTokenResponse>> refreshCoupleAccessToken(@RequestTokens JwtToken jwtToken) {
-        return ResponseEntity.ok().build();
+        AccessTokenResponse accessToken = authFacade.refreshCoupleAccessToken(
+            jwtToken.getAccessToken(),
+            jwtToken.getRefreshToken()
+        );
+        return ResponseEntity.ok(new ApiResponse<>(accessToken));
     }
 
     private void setTokenCookie(HttpServletResponse response, TokenDto tokenDto) {

--- a/src/main/java/com/musseukpeople/woorimap/auth/presentation/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/musseukpeople/woorimap/auth/presentation/resolver/AuthArgumentResolver.java
@@ -17,7 +17,6 @@ import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 import com.musseukpeople.woorimap.common.util.AuthorizationExtractor;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.RequiredTypeException;
 import lombok.RequiredArgsConstructor;
 
@@ -47,23 +46,22 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     private LoginMember getLoginMember(String accessToken) {
-        Claims claims = jwtProvider.getClaims(accessToken);
-        Long id = convertMemberId(accessToken, claims);
-        Long coupleId = convertCoupleId(accessToken, claims);
+        Long id = convertMemberId(accessToken);
+        Long coupleId = convertCoupleId(accessToken);
         return new LoginMember(id, coupleId, accessToken);
     }
 
-    private Long convertMemberId(String token, Claims claims) {
+    private Long convertMemberId(String token) {
         try {
-            return Long.parseLong(claims.getSubject());
+            return Long.parseLong(jwtProvider.getSubject(token));
         } catch (NumberFormatException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }
     }
 
-    private Long convertCoupleId(String token, Claims claims) {
+    private Long convertCoupleId(String token) {
         try {
-            return claims.get(jwtProvider.getClaimName(), Long.class);
+            return jwtProvider.getCoupleId(token);
         } catch (RequiredTypeException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }

--- a/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
+++ b/src/main/java/com/musseukpeople/woorimap/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다."),
     NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "로그인이 필요합니다."),
     BLACKLIST_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "허용되지 않는 토큰입니다."),
+    INVALID_TOKEN_REQUEST(HttpStatus.UNAUTHORIZED, "A004", "토큰을 재발급 할 수 없는 상태입니다."),
 
     // Couple
     NOT_FOUND_COUPLE(HttpStatus.NOT_FOUND, "CP001", "존재하지 않는 커플입니다."),

--- a/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
+++ b/src/main/java/com/musseukpeople/woorimap/event/domain/PostEvent.java
@@ -46,7 +46,7 @@ public class PostEvent implements Serializable {
             post.getCouple().getOpponentMember(sourceId).getId(),
             post.getId(),
             eventType,
-            post.getContent(),
+            post.getTitle(),
             LocalDateTime.now()
         );
     }

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
@@ -115,8 +115,12 @@ public class NotificationService {
     private void sendLostEvent(Long memberId, String lastEventId, String emitterId, SseEmitter sseEmitter) {
         Map<String, Object> events = emitterRepository.findAllEventCacheStartWithByMemberId(memberId + ID_DELIMITER);
         events.entrySet().stream()
-            .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+            .filter(entry -> isLostEvent(lastEventId, entry.getKey()))
             .forEach(entry -> sendNotification(sseEmitter, EVENT_NAME, entry.getKey(), emitterId, entry.getValue()));
+    }
+
+    private boolean isLostEvent(String lastEventId, String eventId) {
+        return lastEventId.compareTo(eventId) < 0;
     }
 
     private void sendNotification(SseEmitter sseEmitter, String eventName, String eventId, String emitterId,

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/NotificationService.java
@@ -64,7 +64,7 @@ public class NotificationService {
         NotificationResponse notificationResponse = NotificationResponse.from(notification);
         emitters.forEach((key, emitter) -> {
                 emitterRepository.saveEventCache(key, notificationResponse);
-                sendNotification(emitter, eventId, key, notificationResponse);
+                sendNotification(emitter, EVENT_NAME, eventId, key, notificationResponse);
             }
         );
     }
@@ -109,21 +109,22 @@ public class NotificationService {
     }
 
     private void sendConnectNotification(SseEmitter sseEmitter, String emitterId, Long memberId) {
-        sendNotification(sseEmitter, emitterId, emitterId, format(CONNECT_EVENT_MESSAGE_FORMAT, memberId));
+        sendNotification(sseEmitter, "connect", emitterId, emitterId, format(CONNECT_EVENT_MESSAGE_FORMAT, memberId));
     }
 
     private void sendLostEvent(Long memberId, String lastEventId, String emitterId, SseEmitter sseEmitter) {
         Map<String, Object> events = emitterRepository.findAllEventCacheStartWithByMemberId(memberId + ID_DELIMITER);
         events.entrySet().stream()
             .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
-            .forEach(entry -> sendNotification(sseEmitter, entry.getKey(), emitterId, entry.getValue()));
+            .forEach(entry -> sendNotification(sseEmitter, EVENT_NAME, entry.getKey(), emitterId, entry.getValue()));
     }
 
-    private void sendNotification(SseEmitter sseEmitter, String eventId, String emitterId, Object data) {
+    private void sendNotification(SseEmitter sseEmitter, String eventName, String eventId, String emitterId,
+                                  Object data) {
         try {
             sseEmitter.send(SseEmitter.event()
                 .id(eventId)
-                .name(EVENT_NAME)
+                .name(eventName)
                 .data(data));
         } catch (IOException e) {
             emitterRepository.deleteById(emitterId);

--- a/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/application/dto/response/NotificationResponse.java
@@ -4,6 +4,7 @@ import static com.musseukpeople.woorimap.notification.domain.Notification.*;
 
 import com.musseukpeople.woorimap.notification.domain.Notification;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,10 +13,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationResponse {
 
+    @Schema(description = "알림 번호")
     private Long id;
+
+    @Schema(description = "컨텐츠 번호")
     private Long contentId;
+
+    @Schema(description = "알림 타입")
     private NotificationType type;
+
+    @Schema(description = "알림 보낸 회원 닉네임")
     private String nickName;
+
+    @Schema(description = "컨텐츠")
     private String content;
 
     public NotificationResponse(Long id, Long contentId, NotificationType type, String nickName, String content) {

--- a/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/domain/NotificationRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    @Query("SELECT n FROM Notification n WHERE n.receiverId = :id AND n.isRead = false ")
+    @Query("SELECT n FROM Notification n WHERE n.receiverId = :id AND n.isRead = false ORDER BY n.id DESC ")
     List<Notification> findUnreadAllByMemberId(@Param("id") Long id);
 }

--- a/src/main/java/com/musseukpeople/woorimap/notification/presentation/resolver/AuthNotificationArgumentResolver.java
+++ b/src/main/java/com/musseukpeople/woorimap/notification/presentation/resolver/AuthNotificationArgumentResolver.java
@@ -16,7 +16,6 @@ import com.musseukpeople.woorimap.auth.domain.login.LoginMember;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
 import com.musseukpeople.woorimap.common.exception.ErrorCode;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.RequiredTypeException;
 import lombok.RequiredArgsConstructor;
 
@@ -49,23 +48,22 @@ public class AuthNotificationArgumentResolver implements HandlerMethodArgumentRe
     }
 
     private LoginMember getLoginMember(String accessToken) {
-        Claims claims = jwtProvider.getClaims(accessToken);
-        Long id = convertMemberId(accessToken, claims);
-        Long coupleId = convertCoupleId(accessToken, claims);
+        Long id = convertMemberId(accessToken);
+        Long coupleId = convertCoupleId(accessToken);
         return new LoginMember(id, coupleId, accessToken);
     }
 
-    private Long convertMemberId(String token, Claims claims) {
+    private Long convertMemberId(String token) {
         try {
-            return Long.parseLong(claims.getSubject());
+            return Long.parseLong(jwtProvider.getSubject(token));
         } catch (NumberFormatException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }
     }
 
-    private Long convertCoupleId(String token, Claims claims) {
+    private Long convertCoupleId(String token) {
         try {
-            return claims.get(jwtProvider.getClaimName(), Long.class);
+            return jwtProvider.getCoupleId(token);
         } catch (RequiredTypeException e) {
             throw new InvalidTokenException(token, ErrorCode.INVALID_TOKEN);
         }

--- a/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
+++ b/src/main/java/com/musseukpeople/woorimap/post/application/PostFacade.java
@@ -51,7 +51,7 @@ public class PostFacade {
         Tags tags = tagService.findOrCreateTags(couple, editPostRequest.getTags());
 
         Post post = postService.modifyPost(tags.getList(), postId, editPostRequest);
-        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post, POST_CREATED));
+        eventPublisher.publishEvent(PostEvent.of(loginMember.getId(), post, POST_MODIFIED));
         return post.getId();
     }
 

--- a/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/acceptance/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.musseukpeople.woorimap.auth.acceptance;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 import java.io.IOException;
 
@@ -161,6 +162,30 @@ class AuthControllerTest extends AcceptanceTest {
 
         // then
         토큰_재발급_실패(response);
+    }
+
+    @DisplayName("커플 상태 변경 시 토큰 재발급 성공")
+    @Test
+    void refreshCoupleAccessToken_success() throws Exception {
+        // given
+        MockHttpServletResponse loginResponse = 로그인(new SignInRequest("woorimap@gmail.com", "!Hwan123"));
+        String accessToken = getAccessToken(loginResponse);
+        String refreshToken = getRefreshToken(loginResponse);
+
+        // when
+        MockHttpServletResponse response = mockMvc.perform(post("/api/auth/couples/token")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .cookie(new Cookie("refreshToken", refreshToken)))
+            .andDo(print())
+            .andReturn().getResponse();
+
+        // then
+        AccessTokenResponse accessTokenResponse = getResponseObject(response, AccessTokenResponse.class);
+        assertAll(
+            () -> assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(accessTokenResponse.getAccessToken()).isNotNull()
+        );
     }
 
     private MockHttpServletResponse 로그아웃(String accessToken) throws Exception {

--- a/src/test/java/com/musseukpeople/woorimap/auth/application/AuthFacadeTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/application/AuthFacadeTest.java
@@ -3,6 +3,9 @@ package com.musseukpeople.woorimap.auth.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,24 +15,36 @@ import com.musseukpeople.woorimap.auth.application.dto.request.SignInRequest;
 import com.musseukpeople.woorimap.auth.application.dto.response.AccessTokenResponse;
 import com.musseukpeople.woorimap.auth.application.dto.response.LoginResponseDto;
 import com.musseukpeople.woorimap.auth.exception.InvalidTokenException;
-import com.musseukpeople.woorimap.member.application.MemberService;
-import com.musseukpeople.woorimap.member.application.dto.request.SignupRequest;
+import com.musseukpeople.woorimap.auth.exception.InvalidTokenRequestException;
+import com.musseukpeople.woorimap.couple.domain.Couple;
+import com.musseukpeople.woorimap.couple.domain.CoupleRepository;
+import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+import com.musseukpeople.woorimap.member.domain.Member;
+import com.musseukpeople.woorimap.member.domain.MemberRepository;
 import com.musseukpeople.woorimap.member.exception.LoginFailedException;
 import com.musseukpeople.woorimap.util.IntegrationTest;
+import com.musseukpeople.woorimap.util.fixture.TMemberBuilder;
 
 class AuthFacadeTest extends IntegrationTest {
 
     private final String email = "woorimap@gmail.com";
     private final String password = "!Hwan123";
+
     @Autowired
     private AuthFacade authFacade;
 
     @Autowired
-    private MemberService memberService;
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CoupleRepository coupleRepository;
+
+    private Member member;
 
     @BeforeEach
     void setUp() {
-        memberService.createMember(new SignupRequest(email, password, "test"));
+        member = new TMemberBuilder().email(email).password(password).build();
+        memberRepository.save(member);
     }
 
     @DisplayName("로그인 성공")
@@ -121,7 +136,63 @@ class AuthFacadeTest extends IntegrationTest {
             .hasMessageContaining("유효하지 않은 토큰입니다.");
     }
 
+    @DisplayName("커플 상태 변환 시 토큰 재발급 성공")
+    @Test
+    void refreshCoupleAccessToken_success() {
+        // given
+        LoginResponseDto loginResponseDto = login(email, password);
+        String accessToken = loginResponseDto.getAccessToken().getValue();
+        String refreshToken = loginResponseDto.getRefreshToken().getValue();
+        makeCouple();
+
+        // when
+        AccessTokenResponse accessTokenResponse = authFacade.refreshCoupleAccessToken(accessToken, refreshToken);
+
+        // then
+        assertThat(accessTokenResponse.getAccessToken()).isNotNull();
+    }
+
+    @DisplayName("커플 상태 변화 없음로 인한 토큰 재발급 실패")
+    @Test
+    void refreshCoupleAccessToken_couple_fail() {
+        // given
+        LoginResponseDto loginResponseDto = login(email, password);
+        String accessToken = loginResponseDto.getAccessToken().getValue();
+        String refreshToken = loginResponseDto.getRefreshToken().getValue();
+
+        // when
+        // then
+        assertThatThrownBy(() -> authFacade.refreshCoupleAccessToken(accessToken, refreshToken))
+            .isInstanceOf(InvalidTokenRequestException.class)
+            .hasMessageContaining("토큰을 재발급 할 수 없는 상태입니다.");
+    }
+
+    @DisplayName("솔로 상태 변화 없음으로 인한 토큰 재발급 실패")
+    @Test
+    void refreshCoupleAccessToken_solo_success() {
+        // given
+        makeCouple();
+        LoginResponseDto loginResponseDto = login(email, password);
+        String accessToken = loginResponseDto.getAccessToken().getValue();
+        String refreshToken = loginResponseDto.getRefreshToken().getValue();
+
+        // when
+        // then
+        assertThatThrownBy(() -> authFacade.refreshCoupleAccessToken(accessToken, refreshToken))
+            .isInstanceOf(InvalidTokenRequestException.class)
+            .hasMessageContaining("토큰을 재발급 할 수 없는 상태입니다.");
+    }
+
     private LoginResponseDto login(String email, String password) {
         return authFacade.login(new SignInRequest(email, password));
+    }
+
+    private void makeCouple() {
+        Member opponentMember = new TMemberBuilder().email("test1@gmail.com").build();
+        memberRepository.save(opponentMember);
+        List<Member> members = List.of(member, opponentMember);
+        Couple couple = coupleRepository.save(new Couple(LocalDate.now(), new CoupleMembers(members)));
+        members.forEach(member -> member.changeCouple(couple));
+        memberRepository.saveAll(members);
     }
 }

--- a/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/com/musseukpeople/woorimap/auth/infrastructure/JwtTokenProviderTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import com.musseukpeople.woorimap.auth.application.dto.TokenDto;
 
-import io.jsonwebtoken.Claims;
-
 class JwtTokenProviderTest {
 
     private static final JwtTokenProvider PROVIDER = new JwtTokenProvider(
@@ -30,12 +28,13 @@ class JwtTokenProviderTest {
         TokenDto accessToken = PROVIDER.createAccessToken(memberId, coupleId);
 
         // when
-        Claims claims = PROVIDER.getClaims(accessToken.getValue());
+        String jwtMemberId = PROVIDER.getSubject(accessToken.getValue());
+        Long jwtCoupleId = PROVIDER.getCoupleId(accessToken.getValue());
 
         // then
         assertAll(
-            () -> assertThat(claims.getSubject()).isEqualTo(memberId),
-            () -> assertThat(claims.get("coupleId", Long.class)).isEqualTo(coupleId)
+            () -> assertThat(jwtMemberId).isEqualTo(memberId),
+            () -> assertThat(jwtCoupleId).isEqualTo(coupleId)
         );
     }
 
@@ -46,7 +45,7 @@ class JwtTokenProviderTest {
         TokenDto refreshToken = PROVIDER.createRefreshToken();
 
         // when
-        String payload = PROVIDER.getClaims(refreshToken.getValue()).getSubject();
+        String payload = PROVIDER.getSubject(refreshToken.getValue());
 
         // then
         assertThat(payload).isNotNull();

--- a/src/test/java/com/musseukpeople/woorimap/util/fixture/TCoupleBuilder.java
+++ b/src/test/java/com/musseukpeople/woorimap/util/fixture/TCoupleBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.musseukpeople.woorimap.couple.domain.Couple;
 import com.musseukpeople.woorimap.couple.domain.vo.CoupleMembers;
+import com.musseukpeople.woorimap.member.domain.Member;
 
 public class TCoupleBuilder {
 
@@ -29,6 +30,11 @@ public class TCoupleBuilder {
 
     public TCoupleBuilder coupleMembers(CoupleMembers coupleMembers) {
         this.members = coupleMembers;
+        return this;
+    }
+
+    public TCoupleBuilder members(List<Member> members) {
+        this.members = new CoupleMembers(members);
         return this;
     }
 


### PR DESCRIPTION
## 요약
- 커플 상태 변경 시 토큰 재발급 API 구현

<br><br>

## 작업 내용
- JwtProvider 리팩토링 (cd01421f602dcef199d814cb91337ed40fcdebd2)
- 커플 상태 변경 시 토큰 재발급 기능 구현 (480f19e646317d57876de3fd66c1333916bcdfea) 
  - 토큰의  커플아이디가 있고 커플이라면 예외, 토큰의 커플아이디가 없고 솔로면 예외가 발생합니다.

<br><br>

## 참고 사항
- 커플이 깨졌을 때 필요하다가 프론트분들이 요청을 해서 구현하였습니다.

<br><br>
