### PR TITLE
[87] refactor: 태그 이름 인덱스 설정

### DIFF
--- a/woorimap-core/src/main/resources/db/migration/V9__add_index_to_tag_name.sql
+++ b/woorimap-core/src/main/resources/db/migration/V9__add_index_to_tag_name.sql
@@ -1,0 +1,1 @@
+create index tag_name_index on tag (couple_id, name);


### PR DESCRIPTION
## 요약
- 태그 이름 인덱스 설정 
<br><br>

## 작업 내용
- 게시물 생성 중 태그 조회 쿼리가 나가게 되는 데 데이터가 많을 경우 인덱스가 없어 느린 쿼리발생
  - 테스트 환경에서 태그는 60만건 적재했음. 
- 이를 해결하고자 태그이름에 인덱스 설정 

<br><br>

## 결과 
![image](https://user-images.githubusercontent.com/65746780/200172930-84d4c1c4-c48c-4470-b10b-967b88815eb0.png)
![인덱스 적용](https://user-images.githubusercontent.com/65746780/200173029-9f7c9546-20a0-4c89-a9f3-2508a7fb2ab1.png)

- 쿼리 시간 5초 -> 0.002초로 개선 
- 테스트시에도 응답 잘 오는 것을 확인할 수 있음.

<br><br>


## 참고 사항
close #87 
